### PR TITLE
Dependencies: Update some known-vulnerable dependencies

### DIFF
--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.2.RELEASE</version>
+		<version>1.5.19.RELEASE</version>
 		<relativePath />
 	</parent>
 
@@ -77,43 +77,46 @@
 		<dependency>
 			<groupId>commons-dbcp</groupId>
 			<artifactId>commons-dbcp</artifactId>
-			<version>1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
-			<version>2.5.0</version>
+			<version>2.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.5.0</version>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>27.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <version>5.2.6.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-java8</artifactId>
-            <version>5.2.6.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <version>5.2.6.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
-        </dependency>
-        <dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>5.2.18.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-java8</artifactId>
+			<version>5.2.18.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>5.2.18.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			</dependency>
+		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.0</version>

--- a/scheduler/src/main/resources/applicationContext.xml
+++ b/scheduler/src/main/resources/applicationContext.xml
@@ -78,7 +78,7 @@
 		<property name="dbStatusCollector" ref="dbStatusCollector"></property>
 	</bean>
 	
-    <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+    <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager" primary="true">
         <property name="entityManagerFactory" ref="entityManagerFactory"/>
     </bean>
     <bean id="policyDbTransactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/EmbeddedTomcatUtil.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/EmbeddedTomcatUtil.java
@@ -49,7 +49,7 @@ public class EmbeddedTomcatUtil {
 		try {
 			tomcat.start();
 			appContext = tomcat.addWebapp("/", applicationDir.getAbsolutePath());
-		} catch (LifecycleException | ServletException e) {
+		} catch (LifecycleException e) {
 			throw new RuntimeException(e);
 		}
 	}


### PR DESCRIPTION
### Description:
Updated some dependencies
* Spring Boot: 1.5.2 to 1.5.19
* Springfox Swagger: 2.5.0 to 2.9.2
* Guava 18 to 27.1
* Hibernate 5.2.6 to 5.2.18
* Apache HTTP Client 4.5.3 to 4.5.6

#### Problems fixed:
Some direct and indirect dependencies where at versions with known
vulnerabilities.