### PR TITLE
Fixed too many log lines when db not available

### DIFF
--- a/src/autoscaler/eventgenerator/aggregator/appManager.go
+++ b/src/autoscaler/eventgenerator/aggregator/appManager.go
@@ -70,16 +70,15 @@ func (am *AppManager) startPolicyRetrieve() {
 
 	for {
 		policyJsons, err := am.retrievePolicies()
-		if err != nil {
-			continue
+		if err == nil {
+			policies := am.computePolicies(policyJsons)
+
+			am.pLock.Lock()
+			am.policyMap = policies
+			am.pLock.Unlock()
+
+			am.refreshMetricCache(policies)
 		}
-		policies := am.computePolicies(policyJsons)
-
-		am.pLock.Lock()
-		am.policyMap = policies
-		am.pLock.Unlock()
-
-		am.refreshMetricCache(policies)
 
 		select {
 		case <-am.doneChan:


### PR DESCRIPTION
This change fixes the problem of writing too many error messages when the policy database is not available. In our landscape this issue lead to problems with the elk stack because up to 10000 log lines / s were written. 
Now, when a database retrieve fails, the retry happens after the specified poll interval.