### PR TITLE
Revert "Fixed too many log lines when db not available"

### DIFF
--- a/src/autoscaler/eventgenerator/aggregator/appManager.go
+++ b/src/autoscaler/eventgenerator/aggregator/appManager.go
@@ -70,15 +70,16 @@ func (am *AppManager) startPolicyRetrieve() {
 
 	for {
 		policyJsons, err := am.retrievePolicies()
-		if err == nil {
-			policies := am.computePolicies(policyJsons)
-
-			am.pLock.Lock()
-			am.policyMap = policies
-			am.pLock.Unlock()
-
-			am.refreshMetricCache(policies)
+		if err != nil {
+			continue
 		}
+		policies := am.computePolicies(policyJsons)
+
+		am.pLock.Lock()
+		am.policyMap = policies
+		am.pLock.Unlock()
+
+		am.refreshMetricCache(policies)
 
 		select {
 		case <-am.doneChan:


### PR DESCRIPTION
Reverts cloudfoundry/app-autoscaler#491 .  Revert due to the incorrect base branch.  Need to merge to develop first. 