### PR TITLE
when operator lost the dblock, it should exit

### DIFF
--- a/src/autoscaler/operator/cmd/operator/main.go
+++ b/src/autoscaler/operator/cmd/operator/main.go
@@ -153,7 +153,9 @@ func main() {
 	}
 	defer lockDB.Close()
 	prdl := sync.NewDatabaseLock(logger)
-	dbLockMaintainer := prdl.InitDBLockRunner(conf.DBLock.LockRetryInterval, conf.DBLock.LockTTL, guid, lockDB)
+	dbLockMaintainer := prdl.InitDBLockRunner(conf.DBLock.LockRetryInterval, conf.DBLock.LockTTL, guid, lockDB, func() {}, func() {
+		os.Exit(1)
+	})
 	members = append(grouper.Members{{"db-lock-maintainer", dbLockMaintainer}}, members...)
 
 	healthServer, err := healthendpoint.NewServer(logger.Session("health-server"), conf.Health.Port, promRegistry)

--- a/src/autoscaler/sync/dblock.go
+++ b/src/autoscaler/sync/dblock.go
@@ -3,7 +3,9 @@ package sync
 import (
 	"autoscaler/db"
 	"autoscaler/models"
+
 	"os"
+	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -11,23 +13,31 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
+const (
+	OwnLock = iota
+	LostLock
+)
+
 type DatabaseLock struct {
 	logger lager.Logger
+	// isHoldLock represents the lock status of the last acquiring.
+	isHoldLock int32
 }
 
 func NewDatabaseLock(logger lager.Logger) *DatabaseLock {
 	return &DatabaseLock{
-		logger: logger,
+		logger:     logger,
+		isHoldLock: LostLock,
 	}
 }
 
-func (dblock *DatabaseLock) InitDBLockRunner(retryInterval time.Duration, ttl time.Duration, owner string, lockDB db.LockDB) ifrit.Runner {
+func (dblock *DatabaseLock) InitDBLockRunner(retryInterval time.Duration, ttl time.Duration, owner string, lockDB db.LockDB, callbackOnAcquiredLock func(), callbackOnLostLock func()) ifrit.Runner {
 	dbLockMaintainer := ifrit.RunFunc(func(signals <-chan os.Signal, ready chan<- struct{}) error {
 		lockTicker := time.NewTicker(retryInterval)
 		readyToAcquireLock := true
 		if owner == "" {
 			dblock.logger.Info("failed-to-get-owner-details")
-			os.Exit(1)
+			callbackOnLostLock()
 		}
 		lock := &models.Lock{Owner: owner, Ttl: ttl}
 		isLockAcquired, lockErr := lockDB.Lock(lock)
@@ -36,7 +46,9 @@ func (dblock *DatabaseLock) InitDBLockRunner(retryInterval time.Duration, ttl ti
 		}
 		if isLockAcquired {
 			readyToAcquireLock = false
+			atomic.StoreInt32(&dblock.isHoldLock, OwnLock)
 			dblock.logger.Info("lock-acquired-in-first-attempt", lager.Data{"owner": owner, "isLockAcquired": isLockAcquired})
+			callbackOnAcquiredLock()
 			close(ready)
 		}
 		for {
@@ -48,6 +60,7 @@ func (dblock *DatabaseLock) InitDBLockRunner(retryInterval time.Duration, ttl ti
 				if releaseErr != nil {
 					dblock.logger.Error("failed-to-release-lock ", releaseErr)
 				} else {
+					atomic.StoreInt32(&dblock.isHoldLock, LostLock)
 					dblock.logger.Debug("successfully-released-lock", lager.Data{"owner": owner})
 				}
 				readyToAcquireLock = true
@@ -63,13 +76,24 @@ func (dblock *DatabaseLock) InitDBLockRunner(retryInterval time.Duration, ttl ti
 					if releaseErr != nil {
 						dblock.logger.Error("failed-to-release-lock ", releaseErr)
 					} else {
+						atomic.StoreInt32(&dblock.isHoldLock, LostLock)
 						dblock.logger.Info("successfully-released-lock", lager.Data{"owner": owner})
 					}
-					os.Exit(1)
+					callbackOnLostLock()
+				}
+				if !isLockAcquired {
+					previousLockStatus := atomic.LoadInt32(&dblock.isHoldLock)
+					if previousLockStatus == OwnLock {
+						dblock.logger.Info("lock-has-been-acquired-by-competitor")
+						atomic.StoreInt32(&dblock.isHoldLock, LostLock)
+						callbackOnLostLock()
+					}
 				}
 				if isLockAcquired && readyToAcquireLock {
 					readyToAcquireLock = false
 					dblock.logger.Info("successfully-acquired-lock", lager.Data{"owner": owner})
+					atomic.StoreInt32(&dblock.isHoldLock, OwnLock)
+					callbackOnAcquiredLock()
 					close(ready)
 				}
 			}

--- a/src/autoscaler/sync/dblock_test.go
+++ b/src/autoscaler/sync/dblock_test.go
@@ -1,0 +1,159 @@
+package sync_test
+
+import (
+	"os"
+	"time"
+
+	"autoscaler/db"
+	"autoscaler/db/sqldb"
+	. "autoscaler/sync"
+
+	"code.cloudfoundry.org/lager/lagertest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+)
+
+var _ = Describe("Dblock", func() {
+	var (
+		lock1       *DatabaseLock
+		lock2       *DatabaseLock
+		lockRunner1 ifrit.Runner
+		lockRunner2 ifrit.Runner
+		lockOwner1  string = "owner1"
+		lockOwner2  string = "owner2"
+		resultOwner string
+		dblogger    *lagertest.TestLogger
+		logger1     *lagertest.TestLogger
+		logger2     *lagertest.TestLogger
+		ldb         *sqldb.LockSQLDB
+		dbConfig    = db.DatabaseConfig{
+			URL:                   os.Getenv("DBURL"),
+			MaxOpenConnections:    10,
+			MaxIdleConnections:    5,
+			ConnectionMaxLifetime: 10 * time.Second,
+		}
+		retryInterval          time.Duration = 5 * time.Second
+		lockTTL                time.Duration = 15 * time.Second
+		signalsChan1           chan os.Signal
+		readyChan1             chan struct{}
+		signalsChan2           chan os.Signal
+		readyChan2             chan struct{}
+		lostLockChan1          chan struct{}
+		lostLockChan2          chan struct{}
+		callbackOnAcquireLock1 func()
+		callbackOnAcquireLock2 func()
+		callbackOnLostLock1    func()
+		callbackOnLostLock2    func()
+		emptyCallback          = func() {}
+		err                    error
+	)
+	BeforeEach(func() {
+		cleanLockTable()
+		dblogger = lagertest.NewTestLogger("lockdb")
+		ldb, err = sqldb.NewLockSQLDB(dbConfig, lockTableName, dblogger)
+		Expect(err).NotTo(HaveOccurred())
+		logger1 = lagertest.NewTestLogger(lockOwner1)
+		logger2 = lagertest.NewTestLogger(lockOwner2)
+		lock1 = NewDatabaseLock(logger1)
+		lock2 = NewDatabaseLock(logger2)
+		signalsChan1 = make(chan os.Signal, 5)
+		signalsChan2 = make(chan os.Signal, 5)
+		readyChan1 = make(chan struct{}, 5)
+		readyChan2 = make(chan struct{}, 5)
+		callbackOnAcquireLock1 = emptyCallback
+		callbackOnAcquireLock2 = emptyCallback
+		callbackOnLostLock1 = emptyCallback
+		callbackOnLostLock2 = emptyCallback
+
+	})
+	JustBeforeEach(func() {
+		lockRunner1 = lock1.InitDBLockRunner(retryInterval, lockTTL, lockOwner1, ldb, callbackOnAcquireLock1, callbackOnLostLock1)
+		lockRunner2 = lock2.InitDBLockRunner(retryInterval, lockTTL, lockOwner2, ldb, callbackOnAcquireLock2, callbackOnLostLock2)
+		go lockRunner1.Run(signalsChan1, readyChan1)
+		go lockRunner2.Run(signalsChan2, readyChan2)
+		select {
+
+		case <-logger1.Buffer().Detect("lock-acquired-in-first-attempt"):
+			resultOwner = lockOwner1
+		case <-logger2.Buffer().Detect("lock-acquired-in-first-attempt"):
+			resultOwner = lockOwner2
+		case <-time.After(2 * time.Second):
+		}
+		logger1.Buffer().CancelDetects()
+		logger2.Buffer().CancelDetects()
+	})
+	AfterEach(func() {
+		signalsChan1 <- os.Kill
+		signalsChan2 <- os.Kill
+		if ldb != nil {
+			err := ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+	It("only one runner can get the lock", func() {
+		Consistently(getLockOwner, 5*retryInterval).Should(Equal(resultOwner))
+	})
+	Context("when locker owner expired", func() {
+		BeforeEach(func() {
+			callbackOnAcquireLock1 = func() {
+				timeout := time.After(lockTTL * 2)
+				for {
+					select {
+					case <-timeout:
+						return
+					default:
+					}
+					if getLockOwner() == lockOwner2 {
+						return
+					}
+					time.Sleep(1 * time.Second)
+				}
+			}
+			callbackOnAcquireLock2 = func() {
+				timeout := time.After(lockTTL * 2)
+				for {
+					select {
+					case <-timeout:
+						return
+					default:
+					}
+					if getLockOwner() == lockOwner1 {
+						return
+					}
+					time.Sleep(1 * time.Second)
+				}
+			}
+			lostLockChan1 = make(chan struct{}, 1)
+			lostLockChan2 = make(chan struct{}, 1)
+			callbackOnLostLock1 = func() {
+				lostLockChan1 <- struct{}{}
+			}
+			callbackOnLostLock2 = func() {
+				lostLockChan2 <- struct{}{}
+			}
+		})
+		It("the expired lock owner should lost the lock and the competitor should get the lock", func() {
+			Eventually(getLockOwner, 5*retryInterval, 1*time.Second).Should(Equal(resultOwner))
+			if resultOwner == lockOwner1 {
+				By("lockowner2 gets the lock due to lockowner1 is expired")
+				Eventually(getLockOwner, 3*lockTTL, 1*time.Second).Should(Equal(lockOwner2))
+				Eventually(lostLockChan1, 3*lockTTL, 1*time.Second).Should(Receive())
+
+				By("lockowner1 gets the lock due to lockowner2 is expired")
+				Eventually(getLockOwner, 3*lockTTL, 1*time.Second).Should(Equal(lockOwner1))
+				Eventually(lostLockChan2, 3*lockTTL, 1*time.Second).Should(Receive())
+			} else {
+				By("lockowner1 gets the lock due to lockowner2 is expired")
+				Eventually(getLockOwner, 3*lockTTL, 1*time.Second).Should(Equal(lockOwner1))
+				Eventually(lostLockChan2, 3*lockTTL, 1*time.Second).Should(Receive())
+
+				By("lockowner2 gets the lock due to lockowner1 is expired")
+				Eventually(getLockOwner, 3*lockTTL, 1*time.Second).Should(Equal(lockOwner2))
+				Eventually(lostLockChan1, 3*lockTTL, 1*time.Second).Should(Receive())
+			}
+		})
+
+	})
+
+})

--- a/src/autoscaler/sync/sync_suite_test.go
+++ b/src/autoscaler/sync/sync_suite_test.go
@@ -1,0 +1,91 @@
+package sync_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	"autoscaler/db"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sync Suite")
+}
+
+var (
+	dbHelper      *sql.DB
+	lockTableName = "test_lock"
+)
+var _ = BeforeSuite(func() {
+	var e error
+
+	dbUrl := os.Getenv("DBURL")
+	if dbUrl == "" {
+		Fail("environment variable $DBURL is not set")
+	}
+
+	dbHelper, e = sql.Open(db.PostgresDriverName, dbUrl)
+	if e != nil {
+		Fail("can not connect database: " + e.Error())
+	}
+
+	e = createLockTable()
+	if e != nil {
+		Fail("can not create test lock table: " + e.Error())
+	}
+
+})
+
+var _ = AfterSuite(func() {
+	if dbHelper != nil {
+		dbHelper.Close()
+	}
+
+})
+
+func getLockOwner() string {
+	var owner string
+	query := fmt.Sprintf("SELECT owner FROM %s", lockTableName)
+	row := dbHelper.QueryRow(query)
+	err := row.Scan(&owner)
+	if err == sql.ErrNoRows {
+		owner = ""
+	}
+	return owner
+}
+
+func cleanLockTable() error {
+	_, err := dbHelper.Exec(fmt.Sprintf("DELETE FROM %s", lockTableName))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func dropLockTable() error {
+	_, err := dbHelper.Exec(fmt.Sprintf("DROP TABLE %s", lockTableName))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createLockTable() error {
+	_, err := dbHelper.Exec(fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			owner VARCHAR(255) PRIMARY KEY,
+			lock_timestamp TIMESTAMP  NOT NULL,
+			ttl BIGINT DEFAULT 0
+		);
+	`, lockTableName))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/autoscaler/sync/sync_suite_test.go
+++ b/src/autoscaler/sync/sync_suite_test.go
@@ -44,6 +44,10 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	if dbHelper != nil {
+		e := dropLockTable()
+		if e != nil {
+			Fail("can not drop test lock table: " + e.Error())
+		}
 		dbHelper.Close()
 	}
 


### PR DESCRIPTION
Currently when a lock owner lost the lock due to expired, it does not exit, so all its jobs keep running while all the competitor's jobs are running as the competitor has acquired the lock.
The right behavior is that when a lock owner lost the lock, all its jobs should exit and later it can be restarted to trying to acquire the lock and before it gets the lock, all its other jobs will not run.