### PR TITLE
monitor metricsgateway nozzle status with prometheus

### DIFF
--- a/src/autoscaler/healthendpoint/counter_collector.go
+++ b/src/autoscaler/healthendpoint/counter_collector.go
@@ -1,0 +1,64 @@
+package healthendpoint
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type CounterCollector interface {
+	prometheus.Collector
+	AddCounters(counterOps ...prometheus.CounterOpts)
+	Add(counterOps prometheus.CounterOpts, count int64)
+}
+
+func NewCounterCollector() CounterCollector {
+	return &counterCollector{
+		counterMap: map[string]prometheus.Counter{},
+	}
+}
+
+type counterCollector struct {
+	counterMap map[string]prometheus.Counter
+	sync.RWMutex
+}
+
+func (c *counterCollector) AddCounters(counterOps ...prometheus.CounterOpts) {
+	c.Lock()
+	defer c.Unlock()
+	for _, ops := range counterOps {
+		counterFullName := getCounterFullName(ops)
+		if _, exists := c.counterMap[counterFullName]; exists {
+			continue
+		}
+		c.counterMap[counterFullName] = prometheus.NewCounter(ops)
+	}
+
+}
+func (c *counterCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.RLock()
+	defer c.RUnlock()
+	for _, counter := range c.counterMap {
+		ch <- counter.Desc()
+	}
+}
+
+func (c *counterCollector) Collect(ch chan<- prometheus.Metric) {
+	c.RLock()
+	defer c.RUnlock()
+	for _, counter := range c.counterMap {
+		ch <- counter
+	}
+}
+
+func (c *counterCollector) Add(counterOps prometheus.CounterOpts, count int64) {
+	c.RLock()
+	defer c.RUnlock()
+	if counter, exists := c.counterMap[getCounterFullName(counterOps)]; exists {
+		counter.Add(float64(count))
+	}
+
+}
+func getCounterFullName(counterOps prometheus.CounterOpts) string {
+	return counterOps.Namespace + "_" + counterOps.Subsystem + "_" + counterOps.Name
+}

--- a/src/autoscaler/healthendpoint/counter_collector_test.go
+++ b/src/autoscaler/healthendpoint/counter_collector_test.go
@@ -1,0 +1,101 @@
+package healthendpoint_test
+
+import (
+	. "autoscaler/healthendpoint"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _ = Describe("CounterCollector", func() {
+	var (
+		namespace1 string = "test_name_space1"
+		subSystem1 string = "test_sub_system1"
+		name1      string = "test_name1"
+		help1      string = "test_help1"
+
+		namespace2 string = "test_name_space2"
+		subSystem2 string = "test_sub_system2"
+		name2      string = "test_name2"
+		help2      string = "test_help2"
+
+		counterOpt1 = prometheus.CounterOpts{
+			Namespace: namespace1,
+			Subsystem: subSystem1,
+			Name:      name1,
+			Help:      help1,
+		}
+		counterOpt2 = prometheus.CounterOpts{
+			Namespace: namespace2,
+			Subsystem: subSystem2,
+			Name:      name2,
+			Help:      help2,
+		}
+
+		descChan         chan *prometheus.Desc
+		metricChan       chan prometheus.Metric
+		counterCollector CounterCollector
+		counterDesc1     = prometheus.NewDesc(
+			prometheus.BuildFQName(namespace1, subSystem1, name1),
+			help1,
+			nil,
+			nil,
+		)
+		counterDesc2 = prometheus.NewDesc(
+			prometheus.BuildFQName(namespace2, subSystem2, name2),
+			help2,
+			nil,
+			nil,
+		)
+		counterMetric1 = prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: namespace1,
+				Subsystem: subSystem1,
+				Name:      name1,
+				Help:      help1,
+			})
+		counterMetric2 = prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: namespace2,
+				Subsystem: subSystem2,
+				Name:      name2,
+				Help:      help2,
+			})
+	)
+	BeforeEach(func() {
+		descChan = make(chan *prometheus.Desc, 10)
+		metricChan = make(chan prometheus.Metric, 10)
+		counterCollector = NewCounterCollector()
+		counterCollector.AddCounters(counterOpt1, counterOpt2)
+	})
+	Context("Describe", func() {
+		BeforeEach(func() {
+			counterCollector.Describe(descChan)
+		})
+		It("receive descriptions", func() {
+			var desc1, desc2 *prometheus.Desc
+			Expect(descChan).To(Receive(&desc1))
+			Expect(descChan).To(Receive(&desc2))
+			Expect([]prometheus.Desc{*desc1, *desc2}).To(ContainElement(*counterDesc1))
+			Expect([]prometheus.Desc{*desc1, *desc2}).To(ContainElement(*counterDesc2))
+		})
+	})
+	Context("Collect", func() {
+		BeforeEach(func() {
+			counterCollector.Add(counterOpt1, 10)
+			counterCollector.Add(counterOpt2, 100)
+			counterCollector.Collect(metricChan)
+			counterMetric1.Add(float64(10))
+			counterMetric2.Add(float64(100))
+		})
+		It("Receive metrics", func() {
+			var metric1, metric2 prometheus.Metric
+			Expect(metricChan).To(Receive(&metric1))
+			Expect(metricChan).To(Receive(&metric2))
+			Expect([]prometheus.Metric{metric1, metric2}).To(ContainElement(prometheus.Metric(counterMetric1)))
+			Expect([]prometheus.Metric{metric1, metric2}).To(ContainElement(prometheus.Metric(counterMetric2)))
+		})
+	})
+
+})

--- a/src/autoscaler/metricsgateway/cmd/metricsgateway/metricsgateway_test.go
+++ b/src/autoscaler/metricsgateway/cmd/metricsgateway/metricsgateway_test.go
@@ -117,6 +117,7 @@ var _ = Describe("Metricsgateway", func() {
 				Expect(healthData).To(ContainSubstring("autoscaler_metricsgateway_policyDB"))
 				Expect(healthData).To(ContainSubstring("go_goroutines"))
 				Expect(healthData).To(ContainSubstring("go_memstats_alloc_bytes"))
+				Expect(healthData).To(ContainSubstring("autoscaler_metricsgateway_envelope_number_from_rlp"))
 				rsp.Body.Close()
 
 			})

--- a/src/autoscaler/metricsgateway/nozzle.go
+++ b/src/autoscaler/metricsgateway/nozzle.go
@@ -63,6 +63,7 @@ type Nozzle struct {
 
 func NewNozzle(logger lager.Logger, index int, shardID string, rlpAddr string, tls *tls.Config, envelopChan chan *loggregator_v2.Envelope, getAppIDsFunc GetAppIDsFunc, envelopeCounterCollector healthendpoint.CounterCollector) *Nozzle {
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	envelopeCounterCollector.AddCounters(envelopeCounter)
 	return &Nozzle{
 		logger:                   logger.Session("Nozzle"),
 		index:                    index,
@@ -78,6 +79,7 @@ func NewNozzle(logger lager.Logger, index int, shardID string, rlpAddr string, t
 }
 
 func (n *Nozzle) Start() {
+	n.envelopeCounterCollector.AddCounters(envelopeCounter)
 	go n.streamMetrics()
 	n.logger.Info("started", lager.Data{"index": n.index})
 }

--- a/src/autoscaler/metricsgateway/nozzle_test.go
+++ b/src/autoscaler/metricsgateway/nozzle_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 
+	"autoscaler/healthendpoint"
 	"autoscaler/metricsgateway"
 	. "autoscaler/testhelpers"
 )
@@ -128,16 +129,17 @@ var _ = Describe("Nozzle", func() {
 			},
 		}
 
-		logger        *lagertest.TestLogger
-		index         = 0
-		shardID       = "autoscaler"
-		envelopChan   chan *loggregator_v2.Envelope
-		getAppIDs     metricsgateway.GetAppIDsFunc
-		nozzle        *metricsgateway.Nozzle
-		rlpAddr       string
-		tlsConf       *tls.Config
-		appIDs        map[string]bool
-		LogServerName string
+		logger                   *lagertest.TestLogger
+		index                    = 0
+		shardID                  = "autoscaler"
+		envelopChan              chan *loggregator_v2.Envelope
+		getAppIDs                metricsgateway.GetAppIDsFunc
+		nozzle                   *metricsgateway.Nozzle
+		rlpAddr                  string
+		tlsConf                  *tls.Config
+		appIDs                   map[string]bool
+		LogServerName            string
+		envelopeCounterCollector = healthendpoint.NewCounterCollector()
 	)
 	BeforeEach(func() {
 		envelopChan = make(chan *loggregator_v2.Envelope, 1000)
@@ -165,7 +167,7 @@ var _ = Describe("Nozzle", func() {
 			Expect(err).NotTo(HaveOccurred())
 			rlpAddr = fakeLoggregator.GetAddr()
 			fakeLoggregator.SetEnvelops(envelopes)
-			nozzle = metricsgateway.NewNozzle(logger, index, shardID, rlpAddr, tlsConf, envelopChan, getAppIDs)
+			nozzle = metricsgateway.NewNozzle(logger, index, shardID, rlpAddr, tlsConf, envelopChan, getAppIDs, envelopeCounterCollector)
 			nozzle.Start()
 		})
 		BeforeEach(func() {
@@ -276,7 +278,7 @@ var _ = Describe("Nozzle", func() {
 			Expect(err).NotTo(HaveOccurred())
 			rlpAddr = fakeLoggregator.GetAddr()
 			fakeLoggregator.SetEnvelops(envelopes)
-			nozzle = metricsgateway.NewNozzle(logger, index, shardID, rlpAddr, tlsConf, envelopChan, getAppIDs)
+			nozzle = metricsgateway.NewNozzle(logger, index, shardID, rlpAddr, tlsConf, envelopChan, getAppIDs, envelopeCounterCollector)
 			nozzle.Start()
 			Eventually(envelopChan).Should(Receive())
 			nozzle.Stop()


### PR DESCRIPTION
output sample:
```
# HELP autoscaler_metricsgateway_envelope_number_from_rlp the total envelopes number got from rlp
# TYPE autoscaler_metricsgateway_envelope_number_from_rlp counter
autoscaler_metricsgateway_envelope_number_from_rlp 10
```