### PR TITLE
fix source code scan issues of nodejs and java in Q2-2019

### DIFF
--- a/api/lib/config/setting.js
+++ b/api/lib/config/setting.js
@@ -44,7 +44,8 @@ module.exports = function(settingsObj) {
     return uri;
   };
   var addProtocol = function (uri) {
-    if (uri && (uri.indexOf("https://") < 0 && uri.indexOf("http://") < 0)) {
+    var pattern = new RegExp("^http[s]{0,1}://");
+    if (uri && (!pattern.test(uri))) {
       uri = "https://" + uri;
     }
     return uri;

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.19.RELEASE</version>
+		<version>1.5.21.RELEASE</version>
 		<relativePath />
 	</parent>
 
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
-			<version>2.2.3</version>
+			<version>2.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -152,6 +152,21 @@
 		  <groupId>io.prometheus</groupId>
 		  <artifactId>simpleclient_httpserver</artifactId>
 		  <version>0.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.8.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.8.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.mchange</groupId>
+			<artifactId>c3p0</artifactId>
+			<version>0.9.5.4</version>
 		</dependency>
     </dependencies>
 

--- a/servicebroker/test/config/setting_test.js
+++ b/servicebroker/test/config/setting_test.js
@@ -47,7 +47,7 @@ describe('config setting Test Suite', function() {
       "serviceCatalogPath" : "catalogPath",
       "schemaValidationPath" : "schemaPath",
       "dashboardRedirectUri": "https://dashboard-redirect-uri-settings.example.com",
-      "customMetricsUrl": "http://metrics.example.com/v1/metrics"
+      "customMetricsUrl": "https://metrics.example.com/v1/metrics"
     };
     settings = configSetting(defaultConfig);
   });


### PR DESCRIPTION
Source code scan issues in `scheduler` (java):

- [x] 1. log4j-core-2.7.jar (OpenSource)
Severity:	High
Location:	/Users/KongJi/.m2/repository/org/apache/logging/log4j/log4j-core/2.7/log4j-core-2.7.jar
Description:	In Apache Log4j 2.x before 2.8.2, when using the TCP socket server or UDP socket server to receive serialized log events from another application, a specially crafted binary payload can be sent that, when deserialized, can execute arbitrary code.
Resolution:	Upgrade To Version 2.8.2

- [x] 2. c3p0-0.9.1.1.jar (OpenSource)
Severity:	Medium
Location: /Users/KongJi/.m2/repository/c3p0/c3p0/0.9.1.1/c3p0-0.9.1.1.jar
Description:	c3p0 version < 0.9.5.4 may be exploited by a billion laughs attack when loading XML configuration due to missing protections against recursive entity expansion when loading configuration.
Resolution:	Upgrade To Version c3p0-0.9.5.4

- [x] 3. spring-data-jpa-1.11.18.RELEASE.jar (OpenSource)
Severity:	Medium
Location:	/Users/KongJi/.m2/repository/org/springframework/data/spring-data-jpa/1.11.18.RELEASE/spring-data-jpa-1.11.18.RELEASE.jar
Description:	Additional information exposure with Spring Data JPA derived queries
Resolution:	Upgrade To Version 1.11.20, 2.0.14, 2.1.6

- [x] 4. tomcat-embed-core-8.5.37.jar (OpenSource)
Severity: Medium
Location: /Users/KongJi/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/8.5.37/tomcat-embed-core-8.5.37.jar
Description: The HTTP/2 implementation in Apache Tomcat 9.0.0.M1 to 9.0.14 and 8.5.0 to 8.5.37 accepted streams with excessive numbers of SETTINGS frames and also permitted clients to keep streams open without reading/writing request/response data. By keeping streams open for requests that utilised the Servlet API's blocking I/O, clients were able to cause server-side threads to block eventually leading to thread exhaustion and a DoS.
Resolution: Upgrade To Version 8.5.38,9.0.14

Source code scan issues in `servicebroker` (nodejs):

- [x] 1. Insecure HTTP Communication
Severity: High
Location: src\test\config\setting_test.js
API: Insecure HTTP Communication
Caller: src\test\config\setting_test.js at line 50
Call: `"http://`

Source code scan issues in `apiserver` (nodejs):
- [x] 1. Insecure HTTP Communication (Communications.Unencrypted)
Severity:	High
Location:	src\lib\config\setting.js
API:	Insecure HTTP Communication
Caller: src\lib\config\setting.js at line 47
Call: `"http://`