### PR TITLE
Api/brokerserver: Allow hashed OSBAPI credentials

### DIFF
--- a/src/autoscaler/api/brokerserver/broker_server_suite_test.go
+++ b/src/autoscaler/api/brokerserver/broker_server_suite_test.go
@@ -24,9 +24,11 @@ import (
 )
 
 const (
-	username  = "brokeruser"
-	password  = "supersecretpassword"
-	testAppId = "an-app-id"
+	username     = "brokeruser"
+	usernameHash = "$2a$12$S44P8nP0b.wq7kW21anaR.uU1dBMCGHUZxw7pdcy42z6oJK0TFTM." // ruby -r bcrypt -e 'puts BCrypt::Password.create("brokeruser")'
+	password     = "supersecretpassword"
+	passwordHash = "$2a$12$8/xRXDhCyl0I..z76PG5Q.pWNLoVs0aYncx6UU1hToRAuevVjKm6O" // ruby -r bcrypt -e 'puts BCrypt::Password.create("supersecretpassword")'
+	testAppId    = "an-app-id"
 )
 
 var (
@@ -50,11 +52,11 @@ var _ = BeforeSuite(func() {
 		BrokerServer: config.ServerConfig{
 			Port: port,
 		},
-		BrokerUsername:    username,
-		BrokerPassword:    password,
-		CatalogPath:       "../exampleconfig/catalog-example.json",
-		CatalogSchemaPath: "../schemas/catalog.schema.json",
-		PolicySchemaPath:  "../policyvalidator/policy_json.schema.json",
+		BrokerUsernameHash: usernameHash,
+		BrokerPasswordHash: passwordHash,
+		CatalogPath:        "../exampleconfig/catalog-example.json",
+		CatalogSchemaPath:  "../schemas/catalog.schema.json",
+		PolicySchemaPath:   "../policyvalidator/policy_json.schema.json",
 		Scheduler: config.SchedulerConfig{
 			SchedulerURL: schedulerServer.URL(),
 		},

--- a/src/autoscaler/api/config/config_test.go
+++ b/src/autoscaler/api/config/config_test.go
@@ -774,8 +774,8 @@ cf:
 				MaxIdleConnections:    5,
 				ConnectionMaxLifetime: 60 * time.Second,
 			}
-			conf.BrokerUsername = "brokeruser"
-			conf.BrokerPassword = "supersecretpassword"
+			conf.BrokerUsernameHash = "$2a$12$BAda.mygPxKmj0StMHZGX.OaezZN73VcRfS8dpaNeBqJ8GS/O16fO"
+			conf.BrokerPasswordHash = "$2a$12$Ksf5cf8sCbpS4WUgMKBMreuxpDhKEBjqwg2Bve.oh03P6iayFux/a"
 			conf.CatalogSchemaPath = "../schemas/catalog.schema.json"
 			conf.CatalogPath = "../exampleconfig/catalog-example.json"
 			conf.PolicySchemaPath = "../exampleconfig/policy.schema.json"
@@ -831,21 +831,79 @@ cf:
 			})
 		})
 
-		Context("when broker username is not set", func() {
+		Context("when neither the broker username nor its hash is set", func() {
 			BeforeEach(func() {
 				conf.BrokerUsername = ""
+				conf.BrokerUsernameHash = ""
 			})
 			It("should err", func() {
-				Expect(err).To(MatchError(MatchRegexp("Configuration error: BrokerUsername is empty")))
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: both broker_username and broker_username_hash are empty, please provide one of them")))
 			})
 		})
 
-		Context("when broker password is not set", func() {
+		Context("when both the broker username and its hash are set", func() {
 			BeforeEach(func() {
-				conf.BrokerPassword = ""
+				conf.BrokerUsername = "brokeruser"
 			})
 			It("should err", func() {
-				Expect(err).To(MatchError(MatchRegexp("Configuration error: BrokerPassword is empty")))
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: both broker_username and broker_username_hash are set, please provide only one of them")))
+			})
+		})
+
+		Context("when just the broker username is set", func() {
+			BeforeEach(func() {
+				conf.BrokerUsername = "brokeruser"
+				conf.BrokerUsernameHash = ""
+			})
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the broker username hash is set to an invalid value", func() {
+			BeforeEach(func() {
+				conf.BrokerUsernameHash = "not a bcrypt hash"
+			})
+			It("should err", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: broker_username_hash is not a valid bcrypt hash")))
+			})
+		})
+
+		Context("when neither the broker password nor its hash is set", func() {
+			BeforeEach(func() {
+				conf.BrokerPassword = ""
+				conf.BrokerPasswordHash = ""
+			})
+			It("should err", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: both broker_password and broker_password_hash are empty, please provide one of them")))
+			})
+		})
+
+		Context("when both the broker password and its hash are set", func() {
+			BeforeEach(func() {
+				conf.BrokerPassword = "brokeruser"
+			})
+			It("should err", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: both broker_password and broker_password_hash are set, please provide only one of them")))
+			})
+		})
+
+		Context("when just the broker password is set", func() {
+			BeforeEach(func() {
+				conf.BrokerPassword = "brokeruser"
+				conf.BrokerPasswordHash = ""
+			})
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the broker password hash is set to an invalid value", func() {
+			BeforeEach(func() {
+				conf.BrokerPasswordHash = "not a bcrypt hash"
+			})
+			It("should err", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: broker_password_hash is not a valid bcrypt hash")))
 			})
 		})
 


### PR DESCRIPTION
### Description:
Allow to specify the OSB API credentials for the service broker to be
specified as `bcrypt` hashes instead of needing to provide the clear
text.

#### Problems fixed:
* The credentials check was not done in constant time.
* The credentials needed to be provided as clear text.