### PR TITLE
api/brokerserver: Handle conflicting service instances

### DIFF
--- a/src/autoscaler/api/brokerserver/broker_handler.go
+++ b/src/autoscaler/api/brokerserver/broker_handler.go
@@ -41,13 +41,17 @@ func NewBrokerHandler(logger lager.Logger, conf *config.Config, bindingdb db.Bin
 
 }
 
+func writeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	handlers.WriteJSONResponse(w, statusCode, models.ErrorResponse{
+		Code:    http.StatusText(statusCode),
+		Message: message})
+}
+
 func (h *BrokerHandler) GetBrokerCatalog(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	catalog, err := ioutil.ReadFile(h.conf.CatalogPath)
 	if err != nil {
 		h.logger.Error("failed to read catalog file", err)
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Failed to load catalog"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to load catalog")
 		return
 	}
 	w.Write([]byte(catalog))
@@ -60,26 +64,19 @@ func (h *BrokerHandler) CreateServiceInstance(w http.ResponseWriter, r *http.Req
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.logger.Error("failed to read service provision request body", err, lager.Data{"instanceId": instanceId})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Failed to read request body"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to read request body")
 		return
 	}
 	err = json.Unmarshal(bodyBytes, body)
 	if err != nil {
 		h.logger.Error("failed to unmarshal service provision body", err, lager.Data{"instanceId": instanceId, "body": string(bodyBytes)})
-		handlers.WriteJSONResponse(w, http.StatusBadRequest, models.ErrorResponse{
-			Code:    "Bad Request",
-			Message: "Invalid request body format"})
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid request body format")
 		return
 	}
 
 	if instanceId == "" || body.OrgGUID == "" || body.SpaceGUID == "" || body.ServiceID == "" || body.PlanID == "" {
 		h.logger.Error("failed to create service instance when trying to get mandatory data", nil, lager.Data{"instanceId": instanceId, "orgGuid": body.OrgGUID, "spaceGuid": body.SpaceGUID, "serviceId": body.ServiceID, "planId": body.PlanID})
-		handlers.WriteJSONResponse(w, http.StatusBadRequest, models.ErrorResponse{
-			Code:    "Bad Request",
-			Message: "Malformed or missing mandatory data",
-		})
+		writeErrorResponse(w, http.StatusBadRequest, "Malformed or missing mandatory data")
 		return
 	}
 
@@ -87,16 +84,11 @@ func (h *BrokerHandler) CreateServiceInstance(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		if err == db.ErrAlreadyExists {
 			h.logger.Error("failed to create service instance: service instance already exists", err, lager.Data{"instanaceId": instanceId, "orgGuid": body.OrgGUID, "spaceGuid": body.SpaceGUID})
-			handlers.WriteJSONResponse(w, http.StatusConflict, models.ErrorResponse{
-				Code:    "Conflict",
-				Message: "Service instance already exists",
-			})
+			writeErrorResponse(w, http.StatusConflict, "Service instance already exists")
 			return
 		}
 		h.logger.Error("failed to create service instance", err, lager.Data{"instanaceId": instanceId, "orgGuid": body.OrgGUID, "spaceGuid": body.SpaceGUID})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error creating service instance"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error creating service instance")
 		return
 	}
 
@@ -114,10 +106,7 @@ func (h *BrokerHandler) DeleteServiceInstance(w http.ResponseWriter, r *http.Req
 	if instanceId == "" {
 		h.logger.Error("failed to delete service instance when trying to get mandatory data", nil,
 			lager.Data{"instanceId": instanceId})
-		handlers.WriteJSONResponse(w, http.StatusBadRequest, models.ErrorResponse{
-			Code:    "Bad Request",
-			Message: "Malformed or missing mandatory data",
-		})
+		writeErrorResponse(w, http.StatusBadRequest, "Malformed or missing mandatory data")
 		return
 	}
 
@@ -126,15 +115,11 @@ func (h *BrokerHandler) DeleteServiceInstance(w http.ResponseWriter, r *http.Req
 		if err == db.ErrDoesNotExist {
 			h.logger.Error("failed to delete service instance: service instance does not exist", err,
 				lager.Data{"instanaceId": instanceId})
-			handlers.WriteJSONResponse(w, http.StatusGone, models.ErrorResponse{
-				Code:    "Gone",
-				Message: "Service Instance Doesn't Exist"})
+			writeErrorResponse(w, http.StatusGone, "Service Instance Doesn't Exist")
 			return
 		}
 		h.logger.Error("failed to delete service instance", err, lager.Data{"instanaceId": instanceId})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error deleting service instance"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error deleting service instance")
 		return
 	}
 
@@ -150,26 +135,19 @@ func (h *BrokerHandler) BindServiceInstance(w http.ResponseWriter, r *http.Reque
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.logger.Error("failed to read bind request body", err, lager.Data{"instanceId": instanceId, "bindingId": bindingId})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Failed to read request body"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to read request body")
 		return
 	}
 	err = json.Unmarshal(bodyBytes, body)
 	if err != nil {
 		h.logger.Error("failed to unmarshal bind body", err, lager.Data{"instanceId": instanceId, "bindingId": bindingId, "body": string(bodyBytes)})
-		handlers.WriteJSONResponse(w, http.StatusBadRequest, models.ErrorResponse{
-			Code:    "Bad Request",
-			Message: "Invalid request body format"})
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid request body format")
 		return
 	}
 
 	if body.AppID == "" || instanceId == "" || bindingId == "" || body.ServiceID == "" || body.PlanID == "" {
 		h.logger.Error("failed to create binding when trying to get mandatory data", nil, lager.Data{"appId": body.AppID, "instanceId": instanceId, "bindingId": bindingId, "serviceId": body.ServiceID, "planId": body.PlanID})
-		handlers.WriteJSONResponse(w, http.StatusBadRequest, models.ErrorResponse{
-			Code:    "Bad Request",
-			Message: "Malformed or missing mandatory data",
-		})
+		writeErrorResponse(w, http.StatusBadRequest, "Malformed or missing mandatory data")
 		return
 	}
 	policyStr := string(body.Policy)
@@ -183,9 +161,7 @@ func (h *BrokerHandler) BindServiceInstance(w http.ResponseWriter, r *http.Reque
 		policyGuid, err = uuid.NewV4()
 		if err != nil {
 			h.logger.Error("failed to create policy guid", err, lager.Data{"appId": body.AppID})
-			handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-				Code:    "Interal-Server-Error",
-				Message: "Error generating policy guid"})
+			writeErrorResponse(w, http.StatusInternalServerError, "Error generating policy guid")
 			return
 		}
 	}
@@ -193,15 +169,11 @@ func (h *BrokerHandler) BindServiceInstance(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		if err == db.ErrAlreadyExists {
 			h.logger.Error("failed to create binding: binding already exists", err, lager.Data{"appId": body.AppID})
-			handlers.WriteJSONResponse(w, http.StatusConflict, models.ErrorResponse{
-				Code:    "Conflict",
-				Message: "An autoscaler service instance is already bound to the application. Multiple bindings are not supported."})
+			writeErrorResponse(w, http.StatusConflict, "An autoscaler service instance is already bound to the application. Multiple bindings are not supported.")
 			return
 		}
 		h.logger.Error("failed to save binding", err, lager.Data{"appId": body.AppID, "bindingId": bindingId, "instanceId": instanceId})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error creating service binding"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error creating service binding")
 		return
 	}
 	cred, err := custom_metrics_cred_helper.CreateCredential(body.AppID, nil, h.policydb, custom_metrics_cred_helper.MaxRetry)
@@ -212,9 +184,7 @@ func (h *BrokerHandler) BindServiceInstance(w http.ResponseWriter, r *http.Reque
 		if err != nil {
 			h.logger.Error("failed to revert binding due to failed to create custom metrics credential", err, lager.Data{"appId": body.AppID})
 		}
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error creating service binding"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error creating service binding")
 		return
 	}
 	if policyStr == "" {
@@ -233,9 +203,7 @@ func (h *BrokerHandler) BindServiceInstance(w http.ResponseWriter, r *http.Reque
 			if err != nil {
 				h.logger.Error("failed to revert binding due to failed to save policy", err, lager.Data{"appId": body.AppID})
 			}
-			handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-				Code:    "Interal-Server-Error",
-				Message: "Error saving policy"})
+			writeErrorResponse(w, http.StatusInternalServerError, "Error saving policy")
 			return
 		}
 
@@ -263,35 +231,25 @@ func (h *BrokerHandler) UnbindServiceInstance(w http.ResponseWriter, r *http.Req
 
 	if instanceId == "" || bindingId == "" {
 		h.logger.Error("failed to delete binding when trying to get mandatory data", nil, lager.Data{"instanceId": instanceId, "bindingId": bindingId})
-		handlers.WriteJSONResponse(w, http.StatusBadRequest, models.ErrorResponse{
-			Code:    "Bad Request",
-			Message: "Malformed or missing mandatory data",
-		})
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid request body format")
 		return
 	}
 	appId, err := h.bindingdb.GetAppIdByBindingId(bindingId)
 	if err == sql.ErrNoRows {
 		h.logger.Info("binding does not exist", nil, lager.Data{"instanceId": instanceId, "bindingId": bindingId})
-		handlers.WriteJSONResponse(w, http.StatusGone, models.ErrorResponse{
-			Code:    "Gone",
-			Message: "Binding does not exist",
-		})
+		writeErrorResponse(w, http.StatusGone, "Binding does not exist")
 		return
 	}
 	if err != nil {
 		h.logger.Error("failed to get appId by bindingId", err, lager.Data{"instanceId": instanceId, "bindingId": bindingId})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error deleting service binding"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error deleting service binding")
 		return
 	}
 	h.logger.Info("deleting policy json", lager.Data{"appId": appId})
 	err = h.policydb.DeletePolicy(appId)
 	if err != nil {
 		h.logger.Error("failed to delete policy for unbinding", err, lager.Data{"appId": appId})
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error deleting policy"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error deleting policy")
 		return
 	}
 	h.logger.Info("deleting schedules", lager.Data{"appId": appId})
@@ -303,14 +261,10 @@ func (h *BrokerHandler) UnbindServiceInstance(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		h.logger.Error("failed to delete binding", err, lager.Data{"bindingId": bindingId, "appId": appId})
 		if err == db.ErrDoesNotExist {
-			handlers.WriteJSONResponse(w, http.StatusGone, models.ErrorResponse{
-				Code:    "Gone",
-				Message: "Service Binding Doesn't Exist"})
+			writeErrorResponse(w, http.StatusGone, "Service Binding Doesn't Exist")
 			return
 		}
-		handlers.WriteJSONResponse(w, http.StatusInternalServerError, models.ErrorResponse{
-			Code:    "Interal-Server-Error",
-			Message: "Error deleting service binding"})
+		writeErrorResponse(w, http.StatusInternalServerError, "Error deleting service binding")
 		return
 	}
 	err = custom_metrics_cred_helper.DeleteCredential(appId, h.policydb, custom_metrics_cred_helper.MaxRetry)

--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -23,6 +23,7 @@ const (
 
 var ErrAlreadyExists = fmt.Errorf("already exists")
 var ErrDoesNotExist = fmt.Errorf("doesn't exist")
+var ErrConflict = fmt.Errorf("conflicting entry exists")
 
 type DatabaseConfig struct {
 	URL                   string        `yaml:"url"`

--- a/src/autoscaler/db/sqldb/binding_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/binding_sqldb_test.go
@@ -23,6 +23,7 @@ var _ = Describe("BindingSqldb", func() {
 		testBindingId  string = "test-binding-id"
 		testAppId      string = "test-app-id"
 		testOrgGuid    string = "test-org-guid"
+		testOrgGuid2   string = "test-org-guid-2"
 		testSpaceGuid  string = "test-space-guid"
 	)
 
@@ -96,6 +97,17 @@ var _ = Describe("BindingSqldb", func() {
 				Expect(err).To(Equal(db.ErrAlreadyExists))
 			})
 		})
+		Context("When a conflicting instance exists", func() {
+			BeforeEach(func() {
+				err = bdb.CreateServiceInstance(testInstanceId, testOrgGuid2, testSpaceGuid)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(db.ErrConflict))
+			})
+		})
+
 	})
 
 	Describe("DeleteServiceInstance", func() {


### PR DESCRIPTION
### Description:
Already existing service instances with conflicting parameters now result in a `409 Conflict`. Also the `dashboard_url` is now returned for non-conflicting service instances.

#### References:
* Spec: https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-3