### PR TITLE
metricsgateway: Allow to specify server name in metricsserver TLS certs

### DIFF
--- a/src/autoscaler/metricsgateway/cmd/metricsgateway/main.go
+++ b/src/autoscaler/metricsgateway/cmd/metricsgateway/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"code.cloudfoundry.org/cfhttp"
 	"crypto/tls"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"code.cloudfoundry.org/cfhttp"
 
 	"autoscaler/db"
 	"autoscaler/db/sqldb"
@@ -50,6 +51,9 @@ func main() {
 		os.Exit(1)
 	}
 	metricServerClientTLSConfig, err := cfhttp.NewTLSConfig(conf.Emitter.MetricsServerClientTLS.CertFile, conf.Emitter.MetricsServerClientTLS.KeyFile, conf.Emitter.MetricsServerClientTLS.CACertFile)
+	if conf.Emitter.MetricsServerTLSServerName != "" {
+		metricServerClientTLSConfig.ServerName = conf.Emitter.MetricsServerTLSServerName
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "%s\n", err.Error())
 		os.Exit(1)

--- a/src/autoscaler/metricsgateway/config/config.go
+++ b/src/autoscaler/metricsgateway/config/config.go
@@ -38,10 +38,11 @@ type NozzleConfig struct {
 }
 
 type EmitterConfig struct {
-	MetricsServerClientTLS *models.TLSCerts `yaml:"metrics_server_client_tls"`
-	BufferSize             int              `yaml:"buffer_size"`
-	KeepAliveInterval      time.Duration    `yaml:"keep_alive_interval"`
-	HandshakeTimeout       time.Duration    `yaml:"handshake_timeout"`
+	MetricsServerClientTLS     *models.TLSCerts `yaml:"metrics_server_client_tls"`
+	MetricsServerTLSServerName string           `yaml:"metrics_server_tls_server_name"`
+	BufferSize                 int              `yaml:"buffer_size"`
+	KeepAliveInterval          time.Duration    `yaml:"keep_alive_interval"`
+	HandshakeTimeout           time.Duration    `yaml:"handshake_timeout"`
 
 	MaxSetupRetryCount int           `yaml:"max_setup_retry_count"`
 	MaxCloseRetryCount int           `yaml:"max_close_retry_count"`


### PR DESCRIPTION
Using the BOSH links feature the metricsgateway get a list of IP
addresses in `metric_server_addrs`, however the metricsservers's DNS
certificate will typically not include those IPs in the SAN.

Now you can specify the server name in the certificate using the
`metrics_server_tls_server_name` config option, allowing the certificate
check to succeed.