### PR TITLE
MetricsCollector: Only process HTTPStartStopEvents with peerType client

### DIFF
--- a/src/autoscaler/metricscollector/collector/app_streamer.go
+++ b/src/autoscaler/metricscollector/collector/app_streamer.go
@@ -107,7 +107,7 @@ func (as *appStreamer) processEvent(event *events.Envelope) {
 	} else if event.GetEventType() == events.Envelope_HttpStartStop {
 		as.logger.Debug("process-event-get-httpstartstop-event", lager.Data{"event": event})
 		ss := event.GetHttpStartStop()
-		if ss != nil {
+		if ss != nil && ss.GetPeerType() == events.PeerType_Client {
 			as.numRequests[ss.GetInstanceIndex()]++
 			as.sumReponseTimes[ss.GetInstanceIndex()] += (ss.GetStopTimestamp() - ss.GetStartTimestamp())
 		}

--- a/src/autoscaler/metricsgateway/cmd/metricsgateway/metricsgateway_suite_test.go
+++ b/src/autoscaler/metricsgateway/cmd/metricsgateway/metricsgateway_suite_test.go
@@ -56,10 +56,13 @@ var (
 	fakeMetricServer    *ghttp.Server
 	metricServerAddress string
 
-	testAppId                            = "test-app-id"
-	envelopes []*loggregator_v2.Envelope = []*loggregator_v2.Envelope{
-		&loggregator_v2.Envelope{
+	testAppId = "test-app-id"
+	envelopes = []*loggregator_v2.Envelope{
+		{
 			SourceId: testAppId,
+			DeprecatedTags: map[string]*loggregator_v2.Value{
+				"peer_type": {Data: &loggregator_v2.Value_Text{Text: "Client"}},
+			},
 			Message: &loggregator_v2.Envelope_Timer{
 				Timer: &loggregator_v2.Timer{
 					Name:  "http",

--- a/src/autoscaler/metricsgateway/nozzle.go
+++ b/src/autoscaler/metricsgateway/nozzle.go
@@ -121,7 +121,7 @@ func (n *Nozzle) filterEnvelopes(envelops []*loggregator_v2.Envelope) {
 					n.envelopChan <- e
 				}
 			case *loggregator_v2.Envelope_Timer:
-				if e.GetTimer().GetName() == "http" {
+				if e.GetTimer().GetName() == "http" && e.GetDeprecatedTags()["peer_type"].GetText() == "Client" {
 					n.logger.Debug("filter-envelopes-get-httpstartstop", lager.Data{"index": n.index, "appID": e.SourceId, "message": e.Message})
 					n.envelopChan <- e
 				}

--- a/src/autoscaler/metricsgateway/nozzle.go
+++ b/src/autoscaler/metricsgateway/nozzle.go
@@ -121,7 +121,12 @@ func (n *Nozzle) filterEnvelopes(envelops []*loggregator_v2.Envelope) {
 					n.envelopChan <- e
 				}
 			case *loggregator_v2.Envelope_Timer:
-				if e.GetTimer().GetName() == "http" && e.GetDeprecatedTags()["peer_type"].GetText() == "Client" {
+				peerType := e.GetTags()["peer_type"]
+				if peerTypeFromDeprecatedTags := e.GetDeprecatedTags()["peer_type"]; peerType == "" && peerTypeFromDeprecatedTags != nil {
+					peerType = peerTypeFromDeprecatedTags.GetText()
+				}
+
+				if e.GetTimer().GetName() == "http" && (peerType == "" || peerType == "Client") {
 					n.logger.Debug("filter-envelopes-get-httpstartstop", lager.Data{"index": n.index, "appID": e.SourceId, "message": e.Message})
 					n.envelopChan <- e
 				}

--- a/src/autoscaler/metricsgateway/nozzle_test.go
+++ b/src/autoscaler/metricsgateway/nozzle_test.go
@@ -110,6 +110,9 @@ var _ = Describe("Nozzle", func() {
 
 		httpStartStopEnvelope = loggregator_v2.Envelope{
 			SourceId: testAppId,
+			DeprecatedTags: map[string]*loggregator_v2.Value{
+				"peer_type": {Data: &loggregator_v2.Value_Text{Text: "Client"}},
+			},
 			Message: &loggregator_v2.Envelope_Timer{
 				Timer: &loggregator_v2.Timer{
 					Name:  "http",

--- a/src/autoscaler/metricsgateway/nozzle_test.go
+++ b/src/autoscaler/metricsgateway/nozzle_test.go
@@ -121,6 +121,19 @@ var _ = Describe("Nozzle", func() {
 				},
 			},
 		}
+		serverHttpStartStopEnvelope = loggregator_v2.Envelope{
+			SourceId: testAppId,
+			DeprecatedTags: map[string]*loggregator_v2.Value{
+				"peer_type": {Data: &loggregator_v2.Value_Text{Text: "Server"}},
+			},
+			Message: &loggregator_v2.Envelope_Timer{
+				Timer: &loggregator_v2.Timer{
+					Name:  "http",
+					Start: 1542325492043447110,
+					Stop:  1542325492045491009,
+				},
+			},
+		}
 		nonHttpStartStopTimerEnvelope = loggregator_v2.Envelope{
 			SourceId: testAppId,
 			Message: &loggregator_v2.Envelope_Timer{
@@ -255,6 +268,17 @@ var _ = Describe("Nozzle", func() {
 			})
 			It("should accept the envelope", func() {
 				Eventually(envelopChan).Should(Receive())
+			})
+		})
+
+		Context("when there is a server httpstartstop timer envelope", func() {
+			BeforeEach(func() {
+				envelopes = []*loggregator_v2.Envelope{
+					&serverHttpStartStopEnvelope,
+				}
+			})
+			It("should not accept the envelope", func() {
+				Eventually(envelopChan).ShouldNot(Receive())
 			})
 		})
 

--- a/src/integration/integration_suite_test.go
+++ b/src/integration/integration_suite_test.go
@@ -855,6 +855,9 @@ func createHTTPTimerEnvelope(appId string, start int64, end int64) []*loggregato
 					Stop:  end,
 				},
 			},
+			DeprecatedTags: map[string]*loggregator_v2.Value{
+				"peer_type": {Data: &loggregator_v2.Value_Text{Text: "Client"}},
+			},
 		},
 	}
 


### PR DESCRIPTION
### Description:
Only process `HTTPStartStop` events with `peerType` `Client`, as they
contain the app instance index in the `instanceIndex` field.

#### Problems fixed:
`HTTPStartStop` events with `peerType` `Server` would be counted against
instance `0` and thus duplicate the number of requests counted by the
App Autoscaler.