### PR TITLE
Update Documentation for Emit metric API Spec

### DIFF
--- a/docs/Public_API.rst
+++ b/docs/Public_API.rst
@@ -1100,7 +1100,7 @@ Status
 **Submit custom metric to Autoscaler metric server**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**PUT /v1/apps/:guid/metrics**
+**POST /v1/apps/:guid/metrics**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Request**


### PR DESCRIPTION
Hi Maintainers, I was working on custom metrics API and found an issue in the documentation [here](https://github.com/cloudfoundry/app-autoscaler/blob/develop/docs/Public_API.rst#put-v1appsguidmetrics)

![image](https://user-images.githubusercontent.com/26872044/87904134-4ffd2600-ca7b-11ea-804c-4ac791252338.png)

As we can see above in the header section the request is documented as a **PUT** request while in route section it is documented as **POST** request. The HTTP request should be same in both the cases as shown above. I tried for my cf provider and only POST request works.

Fixed the misleading documentation for Submit custom metric to Autoscaler metric server API