### PR TITLE
update golang version from 1.13 to 1.15 in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can follow the development progress on [Pivotal Tracker][t].
 * Node 6.2 or above
 * NPM 3.9.5 or above
 * [Cloud Foundry cf command line][f]
-* Go 1.11 or above
+* Go 1.15 or above
 
 ### Database requirement
 


### PR DESCRIPTION
The golang used in autoscaler was upgraded to 1.15.1.  If using old version,  will got error when running the test case. 