### PR TITLE
Don't trigger cooldown if scaling was ignored

### DIFF
--- a/src/autoscaler/scalingengine/scalingengine.go
+++ b/src/autoscaler/scalingengine/scalingengine.go
@@ -165,7 +165,7 @@ func (s *scalingEngine) Scale(appId string, trigger *models.Trigger) (*models.Ap
 		history.Status = models.ScalingStatusIgnored
 		result.Status = history.Status
 		result.Adjustment = 0
-		result.CooldownExpiredAt = now.Add(trigger.CoolDown(s.defaultCoolDownSecs)).UnixNano()
+		result.CooldownExpiredAt = 0
 		return result, nil
 	}
 

--- a/src/autoscaler/scalingengine/scalingengine_test.go
+++ b/src/autoscaler/scalingengine/scalingengine_test.go
@@ -187,7 +187,7 @@ var _ = Describe("ScalingEngine", func() {
 				Expect(scalingResult.AppId).To(Equal("an-app-id"))
 				Expect(scalingResult.Status).To(Equal(models.ScalingStatusIgnored))
 				Expect(scalingResult.Adjustment).To(Equal(0))
-				Expect(scalingResult.CooldownExpiredAt).To(Equal(clock.Now().Add(30 * time.Second).UnixNano()))
+				Expect(scalingResult.CooldownExpiredAt).To(Equal(int64(0)))
 
 			})
 		})
@@ -240,7 +240,7 @@ var _ = Describe("ScalingEngine", func() {
 
 			})
 
-			It("updates the app instance with  max instances and stores the succeeded scaling history", func() {
+			It("updates the app instance with  max instances and stores the ignored scaling history", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(cfc.SetAppInstancesCallCount()).To(BeZero())
@@ -260,7 +260,7 @@ var _ = Describe("ScalingEngine", func() {
 				Expect(scalingResult.AppId).To(Equal("an-app-id"))
 				Expect(scalingResult.Status).To(Equal(models.ScalingStatusIgnored))
 				Expect(scalingResult.Adjustment).To(Equal(0))
-				Expect(scalingResult.CooldownExpiredAt).To(Equal(clock.Now().Add(30 * time.Second).UnixNano()))
+				Expect(scalingResult.CooldownExpiredAt).To(Equal(int64(0)))
 
 			})
 		})


### PR DESCRIPTION
If a scaling was ignored, then the cooldown should also not be
triggered. This was already correctly done in the scalingengine by *not*
updating the `scalingcooldown` entry for the app, but the result
returned to the eventgenerator still contained the new cooldown period.