### PR TITLE
Fail test if certs are not present

### DIFF
--- a/src/autoscaler/api/publicapiserver/publicapiserver_suite_test.go
+++ b/src/autoscaler/api/publicapiserver/publicapiserver_suite_test.go
@@ -85,6 +85,36 @@ var _ = BeforeSuite(func() {
 
 	conf = CreateConfig(true, apiPort)
 
+	// verify Metric Collector certs
+	_, err := ioutil.ReadFile(conf.MetricsCollector.TLSClientCerts.KeyFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile(conf.MetricsCollector.TLSClientCerts.CertFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile(conf.MetricsCollector.TLSClientCerts.CACertFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	// verify EventGenerator certs
+	_, err = ioutil.ReadFile(conf.EventGenerator.TLSClientCerts.KeyFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile(conf.EventGenerator.TLSClientCerts.CertFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile(conf.EventGenerator.TLSClientCerts.CACertFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	// verify EventGenerator certs
+	_, err = ioutil.ReadFile(conf.ScalingEngine.TLSClientCerts.KeyFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile(conf.ScalingEngine.TLSClientCerts.CertFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile(conf.ScalingEngine.TLSClientCerts.CACertFile)
+	Expect(err).NotTo(HaveOccurred())
+
 	fakePolicyDB = &fakes.FakePolicyDB{}
 	checkBindingFunc = func(appId string) bool {
 		return hasBinding

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/eventgenerator_suite_test.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/eventgenerator_suite_test.go
@@ -153,6 +153,13 @@ func initDB() {
 func initHttpEndPoints() {
 	testCertDir := "../../../../../test-certs"
 
+	_, err := ioutil.ReadFile(filepath.Join(testCertDir, "eventgenerator.key"))
+	Expect(err).NotTo(HaveOccurred())
+	_, err = ioutil.ReadFile(filepath.Join(testCertDir, "eventgenerator.crt"))
+	Expect(err).NotTo(HaveOccurred())
+	_, err = ioutil.ReadFile(filepath.Join(testCertDir, "autoscaler-ca.crt"))
+	Expect(err).NotTo(HaveOccurred())
+
 	mcTLSConfig, err := cfhttp.NewTLSConfig(
 		filepath.Join(testCertDir, "metricscollector.crt"),
 		filepath.Join(testCertDir, "metricscollector.key"),

--- a/src/autoscaler/metricsforwarder/cmd/metricsforwarder/metricsforwarder_suite_test.go
+++ b/src/autoscaler/metricsforwarder/cmd/metricsforwarder/metricsforwarder_suite_test.go
@@ -101,11 +101,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	testCertDir := "../../../../../test-certs"
 
-	grpcIngressTestServer, _ = testhelpers.NewTestIngressServer(
+	grpcIngressTestServer, err = testhelpers.NewTestIngressServer(
 		filepath.Join(testCertDir, "metron.crt"),
 		filepath.Join(testCertDir, "metron.key"),
 		filepath.Join(testCertDir, "loggregator-ca.crt"),
 	)
+	Expect(err).NotTo(HaveOccurred())
 
 	err = grpcIngressTestServer.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/src/autoscaler/metricsforwarder/server/server_suite_test.go
+++ b/src/autoscaler/metricsforwarder/server/server_suite_test.go
@@ -6,8 +6,8 @@ import (
 	"autoscaler/metricsforwarder/config"
 	. "autoscaler/metricsforwarder/server"
 	"autoscaler/models"
-
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"time"
 
@@ -37,6 +37,16 @@ func TestServer(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+
+	_, err := ioutil.ReadFile("../../../../test-certs/metron.key")
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile("../../../../test-certs/metron.crt")
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = ioutil.ReadFile("../../../../test-certs/loggregator-ca.crt")
+	Expect(err).NotTo(HaveOccurred())
+
 	return nil
 }, func(_ []byte) {
 

--- a/src/autoscaler/scalingengine/cmd/scalingengine/scalingengine_suite_test.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/scalingengine_suite_test.go
@@ -76,6 +76,9 @@ var _ = SynchronizedBeforeSuite(
 		port = 7000 + GinkgoParallelNode()
 		healthport = 8000 + GinkgoParallelNode()
 		testCertDir := "../../../../../test-certs"
+
+		verifyCertExistence(testCertDir)
+
 		conf.Server.Port = port
 		conf.Server.TLS.KeyFile = filepath.Join(testCertDir, "scalingengine.key")
 		conf.Server.TLS.CertFile = filepath.Join(testCertDir, "scalingengine.crt")
@@ -153,6 +156,15 @@ var _ = SynchronizedBeforeSuite(
 		healthHttpClient = &http.Client{}
 
 	})
+
+func verifyCertExistence(testCertDir string) {
+	_, err := ioutil.ReadFile(filepath.Join(testCertDir, "scalingengine.key"))
+	Expect(err).NotTo(HaveOccurred())
+	_, err = ioutil.ReadFile(filepath.Join(testCertDir, "scalingengine.crt"))
+	Expect(err).NotTo(HaveOccurred())
+	_, err = ioutil.ReadFile(filepath.Join(testCertDir, "autoscaler-ca.crt"))
+	Expect(err).NotTo(HaveOccurred())
+}
 
 var _ = SynchronizedAfterSuite(
 	func() {


### PR DESCRIPTION
**Background:** 
If the testCertDir (and certificates) is not present, the test will fail without  giving appropriate error messages while running ginkgo tests. As a result, it is hard to debug the test failures.

**Implementation:**
The presence of testCerts are checked. If the required certs are not present, the test case will break in the early phase (fail fast).




