### PR TITLE
Experimental .envrc file to configure golang asdf path

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if $(command -v asdf > /dev/null); then
+        GOVERSION=$(asdf current golang | awk '{print $2}')
+	export GOROOT=$HOME/.asdf/installs/golang/$GOVERSION/go
+	PATH_add $HOME/.asdf/installs/golang/$GOVERSION/packages/bin
+fi


### PR DESCRIPTION
Will only configure path and GOROOT if asdf is installed.  This should allow us to have different go versions for different projects