### PR TITLE
fix syntax error in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ start-db: check-db_type target/start-db-${db_type}_CI_${CI} waitfor_${db_type}_C
 
 .PHONY: waitfor_postgres_CI_false waitfor_postgres_CI_true
 target/start-db-postgres_CI_false:
-	@if [ ! "$(shell docker ps -q -f name="^${db_type}$")" ]; then \
-		if [ "$(shell docker ps -aq -f status=exited -f name="^${db_type}$")" ]; then \
+	@if [ ! "$(shell docker ps -q -f name="^${db_type}")" ]; then \
+		if [ "$(shell docker ps -aq -f status=exited -f name="^${db_type}")" ]; then \
 			docker rm ${db_type}; \
 		fi;\
 		echo " - starting docker for ${db_type}";\
@@ -102,8 +102,8 @@ waitfor_postgres_CI_true:
 
 .PHONY: waitfor_mysql_CI_false waitfor_mysql_CI_true
 target/start-db-mysql_CI_false:
-	@if [  ! "$(shell docker ps -q -f name="^${db_type}$")" ]; then \
-		if [ "$(shell docker ps -aq -f status=exited -f name="^${db_type}$")" ]; then \
+	@if [  ! "$(shell docker ps -q -f name="^${db_type}")" ]; then \
+		if [ "$(shell docker ps -aq -f status=exited -f name="^${db_type}")" ]; then \
 			docker rm ${db_type}; \
 		fi;\
 		echo " - starting docker for ${db_type}";\

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ make integration
 make test db_type=mysql
 ```
 
+### Build App-AutoScaler
+```shell
+make build
+```
+
+### Clean up
+You can use the  `make clean` to remove:
+
+* database ( postgres or mysql)
+* autoscaler build artifacts
+
 ### Coding Standards
 Autoscaler uses Golangci and Checkstyle for its code base. Refer to [style-guide](style-guide/README.md)
 


### PR DESCRIPTION
When running make build after make clean, produces the following EOF error.
```
make build
# Installing build tools
# Done
Using bd:postgres
/bin/bash: -c: line 0: unexpected EOF while looking for matching `"'
/bin/bash: -c: line 1: syntax error: unexpected end of file
/bin/bash: -c: line 0: unexpected EOF while looking for matching `"'
/bin/bash: -c: line 1: syntax error: unexpected end of file
 - starting docker for postgres
 - waiting for postgres .. SUCCESS
```

This PR fixes the above error