### PR TITLE
Re-implement plan check in golang service broker

### DIFF
--- a/src/autoscaler/api/brokerserver/broker_handler_test.go
+++ b/src/autoscaler/api/brokerserver/broker_handler_test.go
@@ -144,6 +144,7 @@ var _ = Describe("BrokerHandler", func() {
 		Context("When all parameters are present", func() {
 
 			AfterEach(func() {
+				Expect(tokenServer.ReceivedRequests()).To(HaveLen(1))
 				Expect(quotaServer.ReceivedRequests()).To(HaveLen(1))
 			})
 			Context("When database CreateServiceInstance call returns ErrAlreadyExists", func() {
@@ -249,6 +250,47 @@ var _ = Describe("BrokerHandler", func() {
 					bodyBytes, err := ioutil.ReadAll(resp.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(bodyBytes)).To(Equal(`[{"context":"(root)","description":"instance_max_count is required"}]`))
+				})
+			})
+			Context("When a default policy with too many rules is present", func() {
+				BeforeEach(func() {
+					invalidDefaultPolicy := `
+						{	"instance_max_count":4,
+							"instance_min_count":1,
+							"scaling_rules":[
+							{
+								"metric_type":"memoryused",
+								"threshold":30,
+								"operator":"<",
+								"adjustment":"-1"
+							},
+							{
+								"metric_type":"memoryused",
+								"threshold":30,
+								"operator":"<",
+								"adjustment":"-1"
+							}]
+						}`
+					m := json.RawMessage(invalidDefaultPolicy)
+					instanceCreationReqBody = &models.InstanceCreationRequestBody{
+						OrgGUID:   "an-org-guid",
+						SpaceGUID: "an-space-guid",
+						BrokerCommonRequestBody: models.BrokerCommonRequestBody{
+							ServiceID: "a-service-id",
+							PlanID:    "a-plan-id",
+						},
+						Parameters: models.InstanceParameters{
+							DefaultPolicy: &m,
+						},
+					}
+					body, err = json.Marshal(instanceCreationReqBody)
+					Expect(err).NotTo(HaveOccurred())
+				})
+				It("fails with 400", func() {
+					Expect(resp.Code).To(Equal(http.StatusBadRequest))
+					bodyBytes, err := ioutil.ReadAll(resp.Body)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(bodyBytes)).To(Equal(`{"code":"Bad Request","message":"Too many scaling rules: Found 2 scaling rules, but a maximum of 1 scaling rules are allowed for this service plan. "}`))
 				})
 			})
 			Context("When a default policy is present", func() {
@@ -704,7 +746,42 @@ var _ = Describe("BrokerHandler", func() {
 			})
 
 		})
+		Context("When a policy with too many rules is provided", func() {
+			BeforeEach(func() {
+				bindingPolicy = `{
+					"instance_max_count":4,
+					"instance_min_count":1,
+					"scaling_rules":[
+					{
+						"metric_type":"memoryused",
+						"threshold":30,
+						"operator":"<",
+						"adjustment":"-1"
+					},
+					{
+						"metric_type":"memoryused",
+						"threshold":30,
+						"operator":"<",
+						"adjustment":"-1"
+					}]
+				}`
+				bindingRequestBody = &models.BindingRequestBody{
+					AppID: "an-app-id",
+					BrokerCommonRequestBody: models.BrokerCommonRequestBody{
+						ServiceID: "a-service-id",
+						PlanID:    "a-plan-id",
+					},
+					Policy: json.RawMessage(bindingPolicy),
+				}
 
+				body, err = json.Marshal(bindingRequestBody)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("fails with 400", func() {
+				Expect(resp.Code).To(Equal(http.StatusBadRequest))
+				Expect(resp.Body.String()).To(Equal(`{"code":"Bad Request","message":"Too many scaling rules: Found 2 scaling rules, but a maximum of 1 scaling rules are allowed for this service plan. "}`))
+			})
+		})
 		Context("When mandatory parameters are present", func() {
 			BeforeEach(func() {
 				body, err = json.Marshal(bindingRequestBody)

--- a/src/autoscaler/api/brokerserver/broker_server_suite_test.go
+++ b/src/autoscaler/api/brokerserver/broker_server_suite_test.go
@@ -102,6 +102,15 @@ var _ = BeforeSuite(func() {
 			Secret:   "client-secret",
 			TokenURL: tokenServer.URL(),
 		},
+		PlanCheck: &config.PlanCheckConfig{
+			PlanDefinitions: map[string]config.PlanDefinition{
+				"a-plan-id": {
+					PlanCheckEnabled:  true,
+					SchedulesCount:    1,
+					ScalingRulesCount: 1,
+				},
+			},
+		},
 		CatalogPath:       "../exampleconfig/catalog-example.json",
 		CatalogSchemaPath: "../schemas/catalog.schema.json",
 		PolicySchemaPath:  "../policyvalidator/policy_json.schema.json",

--- a/src/autoscaler/api/config/config.go
+++ b/src/autoscaler/api/config/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	BrokerCredentials    []BrokerCredentialsConfig `yaml:"broker_credentials"`
 	APIClientId          string                    `yaml:"api_client_id"`
 	QuotaManagement      *QuotaManagementConfig    `yaml:"quota_management"`
+	PlanCheck            *PlanCheckConfig          `yaml:"plan_check"`
 	CatalogPath          string                    `yaml:"catalog_path"`
 	CatalogSchemaPath    string                    `yaml:"catalog_schema_path"`
 	DashboardRedirectURI string                    `yaml:"dashboard_redirect_uri"`
@@ -112,6 +113,10 @@ type Config struct {
 	MetricsForwarder     MetricsForwarderConfig    `yaml:"metrics_forwarder"`
 	Health               models.HealthConfig       `yaml:"health"`
 	RateLimit            models.RateLimitConfig    `yaml:"rate_limit"`
+}
+
+type PlanCheckConfig struct {
+	PlanDefinitions map[string]PlanDefinition `yaml:"plan_definitions"`
 }
 
 func LoadConfig(reader io.Reader) (*Config, error) {

--- a/src/autoscaler/api/plancheck/plan_checker.go
+++ b/src/autoscaler/api/plancheck/plan_checker.go
@@ -1,0 +1,55 @@
+package plancheck
+
+import (
+	"autoscaler/api/config"
+	"autoscaler/models"
+	"fmt"
+
+	"code.cloudfoundry.org/lager"
+)
+
+type PlanChecker struct {
+	conf   *config.PlanCheckConfig
+	logger lager.Logger
+}
+
+func NewPlanChecker(config *config.PlanCheckConfig, logger lager.Logger) *PlanChecker {
+	return &PlanChecker{
+		conf:   config,
+		logger: logger.Session("plan-checker"),
+	}
+}
+
+func (pc PlanChecker) CheckPlan(policy models.ScalingPolicy, planID string) (bool, string, error) {
+	if pc.conf == nil {
+		pc.logger.Info("plan-checker-not-configured-allowing-all")
+		return true, "", nil
+	}
+	definition, ok := pc.conf.PlanDefinitions[planID]
+	if !ok {
+		return false, "", fmt.Errorf(`unknown plan id "%s".`, planID)
+	}
+	if !definition.PlanCheckEnabled {
+		return true, "", nil
+	}
+	validationResult := ""
+
+	if policy.Schedules != nil {
+		numSchedules := len(policy.Schedules.RecurringSchedules) + len(policy.Schedules.SpecificDateSchedules)
+		if numSchedules > definition.SchedulesCount {
+			validationResult += fmt.Sprintf("Too many schedules: Found %d schedules, but a maximum of %d schedules are allowed for this service plan. ", numSchedules, definition.SchedulesCount)
+
+		}
+	}
+
+	numScalingRules := len(policy.ScalingRules)
+	if numScalingRules > definition.ScalingRulesCount {
+		validationResult += fmt.Sprintf("Too many scaling rules: Found %d scaling rules, but a maximum of %d scaling rules are allowed for this service plan. ", numScalingRules, definition.SchedulesCount)
+	}
+
+	if validationResult == "" {
+		return true, "", nil
+	} else {
+		return false, validationResult, nil
+	}
+}

--- a/src/autoscaler/api/plancheck/plan_checker.go
+++ b/src/autoscaler/api/plancheck/plan_checker.go
@@ -38,7 +38,6 @@ func (pc PlanChecker) CheckPlan(policy models.ScalingPolicy, planID string) (boo
 		numSchedules := len(policy.Schedules.RecurringSchedules) + len(policy.Schedules.SpecificDateSchedules)
 		if numSchedules > definition.SchedulesCount {
 			validationResult += fmt.Sprintf("Too many schedules: Found %d schedules, but a maximum of %d schedules are allowed for this service plan. ", numSchedules, definition.SchedulesCount)
-
 		}
 	}
 

--- a/src/autoscaler/api/plancheck/plan_checker_suite_test.go
+++ b/src/autoscaler/api/plancheck/plan_checker_suite_test.go
@@ -1,4 +1,4 @@
-package plancheck
+package plancheck_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/src/autoscaler/api/plancheck/plan_checker_suite_test.go
+++ b/src/autoscaler/api/plancheck/plan_checker_suite_test.go
@@ -1,0 +1,13 @@
+package plancheck
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestQuota(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plan Checker Suite")
+}

--- a/src/autoscaler/api/plancheck/plan_checker_test.go
+++ b/src/autoscaler/api/plancheck/plan_checker_test.go
@@ -1,0 +1,162 @@
+package plancheck
+
+import (
+	"autoscaler/api/config"
+	"autoscaler/models"
+
+	"code.cloudfoundry.org/lager/lagertest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PlanCheck", func() {
+	const (
+		testDefaultPolicy = `
+						{
+							"instance_min_count":1,
+							"instance_max_count":5,
+							"scaling_rules":[
+							{
+								"metric_type":"memoryused",
+								"threshold":30,
+								"operator":"<",
+								"adjustment":"-1"
+							}]
+						}`
+	)
+	var (
+		quotaConfig      *config.PlanCheckConfig
+		validationResult string
+		qmc              *PlanChecker
+		ok               bool
+		err              error
+		testPolicy       = models.ScalingPolicy{
+			InstanceMin:  1,
+			InstanceMax:  4,
+			ScalingRules: nil,
+			Schedules:    nil,
+		}
+		testPlanId = "test-plan"
+	)
+	BeforeEach(func() {
+	})
+	Context("CheckPlan", func() {
+		JustBeforeEach(func() {
+			qmc = NewPlanChecker(quotaConfig, lagertest.NewTestLogger("Quota"))
+			ok, validationResult, err = qmc.CheckPlan(testPolicy, testPlanId)
+		})
+		Context("when not configured", func() {
+			It("returns -1", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("when configured", func() {
+			BeforeEach(func() {
+				quotaConfig = &config.PlanCheckConfig{
+					PlanDefinitions: map[string]config.PlanDefinition{
+						"not-checked-plan-id": {
+							false,
+							0,
+							0,
+						},
+						"small-plan-id": {
+							true,
+							1,
+							1,
+						},
+						"large-plan-id": {
+							true,
+							10,
+							10,
+						},
+					},
+				}
+			})
+			Context("when checking a policy with an unknown plan", func() {
+				It("errors on unknown plan", func() {
+					Expect(err).To(HaveOccurred())
+				})
+			})
+			Context("when checking a plan with too many rules", func() {
+				BeforeEach(func() {
+					testPlanId = "small-plan-id"
+					testPolicy = models.ScalingPolicy{
+						ScalingRules: []*models.ScalingRule{
+							{},
+							{},
+						},
+					}
+				})
+				It("fails the check", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(validationResult).NotTo(BeEmpty())
+					Expect(ok).To(BeFalse())
+				})
+			})
+			Context("when checking a plan with enough rules allowed", func() {
+				BeforeEach(func() {
+					testPlanId = "small-plan-id"
+					testPolicy = models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 10,
+						ScalingRules: []*models.ScalingRule{
+							{},
+						},
+					}
+				})
+				It("passes the check", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(validationResult).To(BeEmpty())
+					Expect(ok).To(BeTrue())
+				})
+			})
+			Context("when checking a plan with too many schedules", func() {
+				BeforeEach(func() {
+					testPlanId = "small-plan-id"
+					testPolicy = models.ScalingPolicy{
+						InstanceMin:  1,
+						InstanceMax:  10,
+						ScalingRules: nil,
+						Schedules: &models.ScalingSchedules{
+							Timezone: "",
+							RecurringSchedules: []*models.RecurringSchedule{
+								{},
+							},
+							SpecificDateSchedules: []*models.SpecificDateSchedule{
+								{},
+							},
+						},
+					}
+				})
+				It("fails the check", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(validationResult).NotTo(BeEmpty())
+					Expect(ok).To(BeFalse())
+				})
+			})
+			Context("when checking a plan with enough schedules allowed", func() {
+				BeforeEach(func() {
+					testPlanId = "small-plan-id"
+					testPolicy = models.ScalingPolicy{
+						InstanceMin:  1,
+						InstanceMax:  10,
+						ScalingRules: nil,
+						Schedules: &models.ScalingSchedules{
+							Timezone: "",
+							RecurringSchedules: []*models.RecurringSchedule{
+								{},
+							},
+						},
+					}
+				})
+				It("passes the check", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(validationResult).To(BeEmpty())
+					Expect(ok).To(BeTrue())
+				})
+			})
+		})
+	})
+})

--- a/src/autoscaler/api/plancheck/plan_checker_test.go
+++ b/src/autoscaler/api/plancheck/plan_checker_test.go
@@ -1,4 +1,4 @@
-package plancheck
+package plancheck_test
 
 import (
 	"autoscaler/api/config"
@@ -57,19 +57,19 @@ var _ = Describe("PlanCheck", func() {
 				quotaConfig = &config.PlanCheckConfig{
 					PlanDefinitions: map[string]config.PlanDefinition{
 						"not-checked-plan-id": {
-							false,
-							0,
-							0,
+							PlanCheckEnabled:  false,
+							SchedulesCount:    0,
+							ScalingRulesCount: 0,
 						},
 						"small-plan-id": {
-							true,
-							1,
-							1,
+							PlanCheckEnabled:  true,
+							SchedulesCount:    1,
+							ScalingRulesCount: 1,
 						},
 						"large-plan-id": {
-							true,
-							10,
-							10,
+							PlanCheckEnabled:  true,
+							SchedulesCount:    10,
+							ScalingRulesCount: 10,
 						},
 					},
 				}

--- a/src/autoscaler/api/quota/quota_management_client.go
+++ b/src/autoscaler/api/quota/quota_management_client.go
@@ -59,6 +59,7 @@ func newTransport(shouldSkipTLSValidation bool) *http.Transport {
 // GetQuota Ask the quota manager for instance quota
 func (qmc *Client) GetQuota(orgGUID, serviceName, planName string) (int, error) {
 	if qmc.conf.QuotaManagement == nil {
+		qmc.logger.Info("quota-management-not-configured-allowing-all")
 		return -1, nil // quota management disabled
 	}
 


### PR DESCRIPTION
with the same limitations of the node.js service broker: the adherence
to the plan is only checked on service instance creation (for the
default policy) and binding.