### PR TITLE
Adding preconditions around primarykey addition

### DIFF
--- a/src/autoscaler/scalingengine/db/scalingengine.db.changelog.yml
+++ b/src/autoscaler/scalingengine/db/scalingengine.db.changelog.yml
@@ -254,10 +254,15 @@ databaseChangeLog:
       author: aadeshmisra
       dbms: postgresql
       logicalFilePath: /var/vcap/packages/scalingengine/scalingengine.db.changelog.yml
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - primaryKeyExists:
+              tableName: scalinghistory
+              primaryKeyName: "pk_history"
       changes:
         - addPrimaryKey:
             columnNames: "appid,timestamp"
             constraintName: "pk_history"
-            chemaName: autoscaler
             tableName: scalinghistory
 


### PR DESCRIPTION
Internally this changeset was created with a different `author` causing it to run twice when deploying the OSS release internally.  Adding the precondition check will stop it from running if the pk already exists.