### PR TITLE
(workflow): PR label validation

### DIFF
--- a/.github/workflows/pr-label-check.yaml
+++ b/.github/workflows/pr-label-check.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:
-          mode: exactly one
+          mode: exactly
           count: 1
           labels: "enhancement, bug, chore, breaking-change"


### PR DESCRIPTION
Add GitHub Action to enforce exactly one label on PRs from enhancement, bug, chore, breaking-change