### PR TITLE
chore(editorconfig): Copy `.editorconfig` from `app-autoscaler-release`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+; https://editorconfig.org/
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4
+indent_style = tab
+
+[{*.bash,*.sh}]
+indent_style = tab
+indent_size = 2
+softtabstop = 2
+
+


### PR DESCRIPTION
# Issue

There's no `.editorconfig` in this repository, causing default editor settings to reformat the code.

# Fix

Copy `.editorconfig` from `app-autoscaler-release` to retain settings.
