### PR TITLE
Fix(operator) Avoid Logging Sensitive Information Containng UAA Client Secret

### DIFF
--- a/cf/client.go
+++ b/cf/client.go
@@ -208,7 +208,7 @@ func (c *CtxClient) requestClientCredentialGrant(ctx context.Context, formData *
 func (c *CtxClient) doRequestCredGrant(ctx context.Context, formData *url.Values, credUrl string) (Tokens, error) {
 	tokens := Tokens{}
 	tokenUrl := credUrl + PathCFAuth
-	c.logger.Info("request-client-credential-grant", lager.Data{"tokenURL": tokenUrl, "form": *formData})
+	c.logger.Info("request-client-credential-grant", lager.Data{"tokenURL": tokenUrl})
 
 	req, err := http.NewRequestWithContext(ctx, "POST", tokenUrl, strings.NewReader(formData.Encode()))
 	if err != nil {


### PR DESCRIPTION
**Problem**

The operator service logs Information which contains UAA client secret.

```
time=2025-11-18T06:33:51.636Z level=INFO msg=operator.cf.request-client-credential-grant tokenURL=https://<CF_DOMAIN>/oauth/token form="map[client_id:[uaa_client_id_new] client_secret:[<SECRET>] grant_type:[client_credentials]]" session=4
```


**Fix**

Do not log formData containng sensitive information 