### PR TITLE
chore: disable Spring auto-configuration from Java buildpack

### DIFF
--- a/mta.tpl.yaml
+++ b/mta.tpl.yaml
@@ -25,6 +25,7 @@ modules:
     path: .
     properties:
       JBP_LOG_LEVEL:
+      JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
       LOG_LEVEL: INFO
       DEBUG:
     build-parameters:
@@ -212,6 +213,7 @@ modules:
     properties:
       JBP_LOG_LEVEL:
       JBP_CONFIG_OPEN_JDK_JRE: '{ "version": "21.+", "jre": { "version": "21.+", "java_home": ".java-buildpack/java_home" } }'
+      JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
       DEBUG:
     requires:
     - name: scheduler-config


### PR DESCRIPTION
# Issue

We are currently getting a deprecation warning when staging Java apps:

```
 2025-12-09T09:56:38.82+0100 [STG/0] OUT **WARNING** ATTENTION: The Spring Auto Reconfiguration and shaded Spring Cloud Connectors libraries are being installed. These projects have been deprecated, are no longer receiving updates and should not be used going forward.
   2025-12-09T09:56:38.82+0100 [STG/0] OUT **WARNING** If you are not using these libraries, set `JBP_CONFIG_SPRING_AUTO_RECONFIGURATION='{enabled: false}'` to disable their installation and clear this warning message. The buildpack will switch its default to disable by default after March 2023. Spring Auto Reconfiguration and its shaded Spring Cloud Connectors will be removed from the buildpack after March 2024.
   2025-12-09T09:56:38.82+0100 [STG/0] OUT **WARNING** If you are using these libraries, please migrate to java-cfenv immediately. See https://via.vmw.com/EiBW for migration instructions. Once you upgrade this message will go away.
```

# Fix

As suggested in the warning, disable Spring Auto Reconfiguration
