### PR TITLE
↓{} Downgrade to json-schema version draft-04;

### DIFF
--- a/api/policyvalidator/json-schema/legacy.schema.json
+++ b/api/policyvalidator/json-schema/legacy.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-05/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for scaling-policies for Autoscaler",
   "type": "object",
 

--- a/api/policyvalidator/json-schema/meta.schema.json
+++ b/api/policyvalidator/json-schema/meta.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-05/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Autoscaler Policy JSON Schema",
   "description": "Unification of different schemas for scaling-policies for Autoscaler",
 

--- a/api/policyvalidator/json-schema/v0.1/meta.schema.json
+++ b/api/policyvalidator/json-schema/v0.1/meta.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-05/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Autoscaler Policy JSON Schema",
   "description": "Unification of different schemas for scaling-policies for Autoscaler",
 

--- a/api/policyvalidator/json-schema/v0.1/policy-configuration.schema.json
+++ b/api/policyvalidator/json-schema/v0.1/policy-configuration.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-05/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Autoscaler Scaling Policy Configuration Schema",
   "description": "Schema for the configuration options of scaling policy.",
   "type": "object",

--- a/api/policyvalidator/json-schema/v0.1/scaling-policy.schema.json
+++ b/api/policyvalidator/json-schema/v0.1/scaling-policy.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-05/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for scaling-policies for Autoscaler",
   "type": "object",
 

--- a/api/policyvalidator/json-schema/v0.1/service-key_only.schema.json
+++ b/api/policyvalidator/json-schema/v0.1/service-key_only.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-05/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Minimal schema for a service-key-creation.",
   "type": "object",
 


### PR DESCRIPTION
Some cloudcontrollers only support json-schema until version-4. Hence this PR downgrades from draft-5. As the ladder is a strict subset of draft-4, this is not a breaking change at all and no new schema-version is needed.