### PR TITLE
fix autoscaler cleanup deployments

### DIFF
--- a/scripts/cleanup-autoscaler-deployments.sh
+++ b/scripts/cleanup-autoscaler-deployments.sh
@@ -12,6 +12,7 @@ function get_autoscaler_deployments(){
 }
 
 function main(){
+	bbl_login
 	cf_login
 	local deployments
 	deployments=$(get_autoscaler_deployments)


### PR DESCRIPTION
This pull request makes a small update to the `scripts/cleanup-autoscaler-deployments.sh` script by ensuring that `bbl_login` is called at the start of the `main` function. This guarantees that the environment is properly authenticated before proceeding with the rest of the script.