### PR TITLE
ci: add DevBox Docker image build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Git files
+.git
+.gitignore
+.gitattributes
+
+# CI/CD
+.github
+
+# DevBox runtime
+.devbox
+.direnv
+
+# Claude
+.claude
+
+# Build artifacts
+dist
+build
+target
+*.jar
+*.class
+*.o
+*.a
+
+# Go
+vendor
+bin
+
+# Test files
+*_test.go
+*_test.java
+test
+tests
+
+# Documentation
+*.md
+docs
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.github/workflows/build-devbox-image.yaml
+++ b/.github/workflows/build-devbox-image.yaml
@@ -1,0 +1,77 @@
+name: Build DevBox Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'devbox.json'
+      - 'devbox.lock'
+      - 'Dockerfile'
+      - '.github/workflows/build-devbox-image.yaml'
+  pull_request:
+    paths:
+      - 'devbox.json'
+      - 'devbox.lock'
+      - 'Dockerfile'
+      - '.github/workflows/build-devbox-image.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/devbox
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build Docker image
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-devbox-image.yaml
+++ b/.github/workflows/build-devbox-image.yaml
@@ -51,7 +51,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Use Ubuntu as base image for better DevBox compatibility
+FROM ubuntu:24.04
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies required by DevBox and Nix
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    xz-utils \
+    ca-certificates \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user for DevBox
+RUN useradd -m -s /bin/bash devbox && \
+    echo "devbox ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Switch to devbox user
+USER devbox
+WORKDIR /home/devbox
+
+# Install Nix (required by DevBox)
+RUN curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+
+# Add Nix to PATH for subsequent commands
+ENV PATH="/home/devbox/.nix-profile/bin:${PATH}"
+
+# Install DevBox
+RUN curl -fsSL https://get.jetify.com/devbox | bash
+
+# Add DevBox to PATH
+ENV PATH="/home/devbox/.local/bin:${PATH}"
+
+# Copy DevBox configuration files
+COPY --chown=devbox:devbox devbox.json devbox.lock ./
+
+# Initialize DevBox and install all packages
+# This will download and cache all the packages from your devbox.json
+RUN devbox install
+
+# Set up shell environment
+RUN echo 'eval "$(devbox shellenv)"' >> ~/.bashrc
+
+# Default command to enter DevBox shell
+CMD ["devbox", "shell"]


### PR DESCRIPTION
## Summary
- Add GitHub Action workflow to build and publish Docker image with all DevBox dependencies
- Enable using pre-built DevBox environment in CI/CD and local development
- Image automatically rebuilds when devbox.json or devbox.lock changes

## Changes
- **Dockerfile**: Ubuntu-based image with Nix, DevBox, and all project dependencies pre-installed
- **GitHub Actions workflow**: Builds and pushes to GHCR on main branch updates
- **.dockerignore**: Optimizes build context size

## Image Usage
Once merged, the image will be available at:
```
ghcr.io/cloudfoundry/app-autoscaler/devbox:latest
```

Can be used in workflows:
```yaml
container:
  image: ghcr.io/cloudfoundry/app-autoscaler/devbox:latest
```

## Test plan
- [ ] Workflow runs successfully on PR
- [ ] Image builds without errors
- [ ] After merge, image is pushed to GHCR
- [ ] Image contains all DevBox tools