### PR TITLE
fix(ci): use stable deployment name for main branch pushes

### DIFF
--- a/.github/workflows/acceptance_tests_mta.yaml
+++ b/.github/workflows/acceptance_tests_mta.yaml
@@ -16,6 +16,6 @@ jobs:
     name: "${{ github.workflow }}"
     uses: ./.github/workflows/acceptance_tests_reusable.yaml
     with:
-      deployment_name: "autoscaler-mta-${{ github.event.pull_request.number }}"
+      deployment_name: "autoscaler-mta-${{ github.event.pull_request.number || 'main' }}"
     secrets:
       bbl_ssh_key: "${{ secrets.BBL_SSH_KEY }}"

--- a/.github/workflows/acceptance_tests_reusable.yaml
+++ b/.github/workflows/acceptance_tests_reusable.yaml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  PR_NUMBER: "${{ github.event.pull_request.number }}"
+  PR_NUMBER: "${{ github.event.pull_request.number || 'main' }}"
   DEPLOYMENT_NAME: "${{ inputs.deployment_name }}"
   BBL_STATE_PATH: "${{ github.workspace }}/bbl/bbl-state"
   GINKGO_OPTS: "--fail-fast"


### PR DESCRIPTION
## Summary
- Fixes failing acceptance tests on main branch caused by null `github.event.pull_request.number` in push events
- Adds fallback to `'main'` string for stable deployment naming across successive main branch runs
- Prevents zombie deployments by ensuring each main push targets the same `autoscaler-mta-main` deployment

## Root Cause
When acceptance tests trigger on `push` to main (added in commit ee572739), `github.event.pull_request` is null because it's not a pull_request event. This caused:
- Empty deployment names: `autoscaler-mta-` instead of `autoscaler-mta-123`
- Empty PR_NUMBER env var
- CF tasks named with `prunknown` instead of proper identifiers

