### PR TITLE
chore: reenable `ogen` updates and add workflows to prevent unsupported Otel SDK updates

### DIFF
--- a/.github/workflows/otel-sdk-version-check.yaml
+++ b/.github/workflows/otel-sdk-version-check.yaml
@@ -1,0 +1,79 @@
+name: OTel SDK Dynatrace Compatibility Check
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+    paths:
+      - go.mod
+      - .github/workflows/otel-sdk-version-check.yaml
+      - scripts/check_otel_sdk_version.py
+
+concurrency:
+  group: "${{ github.workflow }}/${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-otel-sdk-version:
+    name: Check OTel SDK Dynatrace compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Check OTel SDK version compatibility
+        id: check
+        run: uv run scripts/check_otel_sdk_version.py go.mod
+        continue-on-error: true
+
+      - name: Request changes on PR
+        if: steps.check.outcome == 'failure' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ steps.check.outputs.comment_body }}
+        run: |
+          printf '%s\n' "${COMMENT_BODY}" > /tmp/review-body.md
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --request-changes \
+            --body-file /tmp/review-body.md
+
+      - name: Dismiss previous review
+        if: steps.check.outcome == 'success' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Find and dismiss any previous "request changes" review from github-actions[bot]
+          review_id=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "CHANGES_REQUESTED")] | last | .id')
+          if [ -n "${review_id}" ] && [ "${review_id}" != "null" ]; then
+            gh api \
+              --method PUT \
+              "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${review_id}/dismissals" \
+              -f message="OTel SDK version is now within a supported Dynatrace range." \
+              -f event="DISMISS"
+          fi
+
+      - name: Fail if unsupported
+        if: steps.check.outcome == 'failure'
+        env:
+          COMMENT_BODY: ${{ steps.check.outputs.comment_body }}
+        run: |
+          if [ -n "${COMMENT_BODY}" ]; then
+            echo "::error::${COMMENT_BODY}"
+          fi
+          exit 1

--- a/.github/workflows/renovate_config_validation.yaml
+++ b/.github/workflows/renovate_config_validation.yaml
@@ -1,0 +1,22 @@
+name: Renovate Config validation
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches:
+      - main
+    paths:
+      - .github/workflows/renovate_config_validation.yaml
+      - renovate.json
+
+jobs:
+  renovate-config-validation:
+    runs-on: ubuntu-latest
+    name: Validate the Renovate configuration
+    steps:
+      - name: Validate the Renovate JSON
+        run: |
+          set -euxo pipefail
+          npx --yes --package renovate -- renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -55,8 +55,7 @@
       "description": "Disable OpenTelemetry-relevant updates",
       "groupName": "opentelemetry",
       "matchPackageNames": [
-        "/opentelemetry/",
-        "/ogen-go/ogen/"
+        "/opentelemetry/"
       ],
       "enabled": false
     },

--- a/scripts/check_otel_sdk_version.py
+++ b/scripts/check_otel_sdk_version.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "beautifulsoup4>=4.14.3",
+#     "packaging>=26.0",
+#     "requests>=2.33.1",
+# ]
+# ///
+"""Check if the OpenTelemetry SDK version in go.mod is supported by Dynatrace OneAgent."""
+
+import re
+import sys
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+from packaging.version import Version
+
+
+DOCS_URL = (
+    "https://docs.dynatrace.com/docs/ingest-from/"
+    "dynatrace-oneagent/oneagent-and-opentelemetry/configuration"
+)
+
+GO_MOD_OTEL_SDK_PATTERN = re.compile(
+    r"go\.opentelemetry\.io/otel/sdk\s+v(\S+)"
+)
+
+VERSION_RANGE_PATTERN = re.compile(
+    r"^(?P<low>\d+(?:\.\d+)*)\s*-\s*(?P<high>\d+(?:\.\d+)*)$"
+)
+
+
+def get_otel_sdk_version(go_mod_path: str) -> str:
+    """Extract the go.opentelemetry.io/otel/sdk version from go.mod."""
+    text = Path(go_mod_path).read_text()
+    match = GO_MOD_OTEL_SDK_PATTERN.search(text)
+    if not match:
+        print("::error::go.opentelemetry.io/otel/sdk not found in go.mod")
+        sys.exit(1)
+    return match.group(1)
+
+
+def get_supported_version_ranges() -> list[str]:
+    """Scrape supported OTel version ranges from Dynatrace docs."""
+    resp = requests.get(DOCS_URL, timeout=30)
+    resp.raise_for_status()
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    go_panel = soup.find(attrs={"aria-labelledby": "prereq--go"})
+    if not go_panel:
+        print("::error::Go tab panel not found on the Dynatrace docs page")
+        sys.exit(1)
+
+    table = go_panel.find("table")
+    if not table:
+        print("::error::Version table not found in Go tab panel")
+        sys.exit(1)
+
+    version_spans = table.select(
+        'span[aria-label="Show Dynatrace OneAgent version support info"]'
+    )
+    versions = []
+    for span in version_spans:
+        text_el = span.find(attrs={"data-dt-component": "Text"})
+        if text_el:
+            versions.append(text_el.get_text(strip=True))
+
+    if not versions:
+        print("::error::No version ranges found in the Dynatrace docs")
+        sys.exit(1)
+
+    return versions
+
+
+def is_version_in_range(version_str: str, range_str: str) -> bool:
+    """Check if a version falls within a given 'low - high' range."""
+    match = VERSION_RANGE_PATTERN.match(range_str.strip())
+    if not match:
+        return False
+
+    ver = Version(version_str)
+    low = Version(match.group("low"))
+    high = Version(match.group("high"))
+    return low <= ver <= high
+
+
+def main() -> None:
+    go_mod_path = sys.argv[1] if len(sys.argv) > 1 else "go.mod"
+
+    sdk_version = get_otel_sdk_version(go_mod_path)
+    print(f"OTel SDK version in go.mod: {sdk_version}")
+
+    supported_ranges = get_supported_version_ranges()
+    print(f"Supported version ranges from Dynatrace docs: {supported_ranges}")
+
+    for version_range in supported_ranges:
+        if is_version_in_range(sdk_version, version_range):
+            print(
+                f"Version {sdk_version} is within supported range"
+                f" '{version_range}'."
+            )
+            return
+
+    # Not supported — output for GitHub Actions
+    ranges_formatted = ", ".join(supported_ranges)
+    message = (
+        f"The OpenTelemetry SDK version `v{sdk_version}` in `go.mod` is"
+        f" **not supported** by Dynatrace OneAgent.\n\n"
+        f"Supported version ranges (from [Dynatrace docs]({DOCS_URL}#prereq--go)):\n"
+    )
+    for r in supported_ranges:
+        message += f"- `{r}`\n"
+    message += (
+        "\nPlease verify Dynatrace OneAgent compatibility before merging."
+    )
+
+    print(f"\n::error::OTel SDK v{sdk_version} is not in supported ranges: {ranges_formatted}")
+
+    # Write outputs for the workflow
+    import os
+
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        with open(github_output, "a") as f:
+            # Use multiline syntax for the comment body
+            f.write("supported=false\n")
+            f.write(f"sdk_version={sdk_version}\n")
+            delimiter = "EOF_COMMENT_BODY"
+            f.write(f"comment_body<<{delimiter}\n")
+            f.write(message)
+            f.write(f"\n{delimiter}\n")
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Issue

`ogen` was not updated due to fears that it would update the OpenTelemetry SDK beyond what's supported by Dynatrace

# Fix

- Reenable `ogen` updates
- Check via workflow that any PR updating `OpenTelemetry` does not go beyond what's supported by Dynatrace

# Also

Reinstate `renovate.json` validation workflow.

# AI Disclosure

The workflow to check Dynatrace compat was created by Claude.
