### PR TITLE
Fix for Missing error check

### DIFF
--- a/integration/gorouterproxy/main.go
+++ b/integration/gorouterproxy/main.go
@@ -131,11 +131,11 @@ func forwardRequest(inRequest *http.Request, cert *auth.Cert) (*http.Response, e
 	url.Host = fmt.Sprintf("127.0.0.1:%s", *forwardTo)
 
 	outRequest, err := http.NewRequest(inRequest.Method, url.String(), inRequest.Body)
-	outRequest.Header = inRequest.Header
 	if err != nil {
 		logger.Printf("Error creating request: %v", err)
 		return nil, err
 	}
+	outRequest.Header = inRequest.Header
 
 	if cert.GetXFCCHeader() == "" {
 		log.Printf("XFCC header is empty")


### PR DESCRIPTION
# Issue

Small issue found by CodeQL, result was used before error checking.

# Fix

The fix is to move the error check immediately after `http.NewRequest(...)` and only access `outRequest` after confirming `err == nil`.

_Suggested fix powered by Copilot Autofix._