### PR TITLE
fix: prevent scalingengine panic on WriteHeader(0)

### DIFF
--- a/cf/errors.go
+++ b/cf/errors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
@@ -126,9 +127,21 @@ func MapCFClientError(err error) error {
 		return nil
 	}
 
+	var cfHTTPErr resource.CloudFoundryHTTPError
+	if errors.As(err, &cfHTTPErr) {
+		return &CfError{
+			StatusCode: cfHTTPErr.StatusCode,
+			Errors: []CfErrorItem{{
+				Title:  cfHTTPErr.Status,
+				Detail: string(cfHTTPErr.Body),
+			}},
+		}
+	}
+
 	var cfClientErr resource.CloudFoundryError
 	if errors.As(err, &cfClientErr) {
 		return &CfError{
+			StatusCode: httpStatusFromCFCode(cfClientErr.Code),
 			Errors: []CfErrorItem{{
 				Code:   cfClientErr.Code,
 				Title:  cfClientErr.Title,
@@ -140,15 +153,32 @@ func MapCFClientError(err error) error {
 	var cfClientErrs resource.CloudFoundryErrors
 	if errors.As(err, &cfClientErrs) {
 		items := make([]CfErrorItem, len(cfClientErrs.Errors))
+		statusCode := 0
 		for i, e := range cfClientErrs.Errors {
 			items[i] = CfErrorItem{
 				Code:   e.Code,
 				Title:  e.Title,
 				Detail: e.Detail,
 			}
+			if statusCode == 0 {
+				statusCode = httpStatusFromCFCode(e.Code)
+			}
 		}
-		return &CfError{Errors: items}
+		return &CfError{StatusCode: statusCode, Errors: items}
 	}
 
 	return err
+}
+
+func httpStatusFromCFCode(cfCode int) int {
+	switch cfCode {
+	case cfResourceNotFound:
+		return http.StatusNotFound
+	case cfNotAuthenticated:
+		return http.StatusUnauthorized
+	case cfNotAuthorised:
+		return http.StatusForbidden
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/cf/errors_test.go
+++ b/cf/errors_test.go
@@ -3,8 +3,10 @@ package cf_test
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/cf"
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -122,6 +124,71 @@ var _ = Describe("Errors test", func() {
 			It("Should return false for IsNotFound()", func() {
 				Expect(cfError.IsNotFound()).To(BeFalse())
 			})
+		})
+	})
+
+	Context("MapCFClientError", func() {
+		It("returns nil for nil error", func() {
+			Expect(cf.MapCFClientError(nil)).To(BeNil())
+		})
+
+		It("maps CloudFoundryError with not-found code to 404", func() {
+			err := resource.CloudFoundryError{Code: 10010, Title: "CF-ResourceNotFound", Detail: "App not found"}
+			result := cf.MapCFClientError(err)
+			var cfErr *cf.CfError
+			Expect(errors.As(result, &cfErr)).To(BeTrue())
+			Expect(cfErr.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(cfErr.Errors[0].Code).To(Equal(10010))
+		})
+
+		It("maps CloudFoundryError with not-authenticated code to 401", func() {
+			err := resource.CloudFoundryError{Code: 10002, Title: "CF-NotAuthenticated", Detail: "No auth token"}
+			result := cf.MapCFClientError(err)
+			var cfErr *cf.CfError
+			Expect(errors.As(result, &cfErr)).To(BeTrue())
+			Expect(cfErr.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("maps CloudFoundryError with not-authorized code to 403", func() {
+			err := resource.CloudFoundryError{Code: 10003, Title: "CF-NotAuthorized", Detail: "No permission"}
+			result := cf.MapCFClientError(err)
+			var cfErr *cf.CfError
+			Expect(errors.As(result, &cfErr)).To(BeTrue())
+			Expect(cfErr.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("maps unknown CloudFoundryError code to 500", func() {
+			err := resource.CloudFoundryError{Code: 99999, Title: "CF-Unknown", Detail: "Something"}
+			result := cf.MapCFClientError(err)
+			var cfErr *cf.CfError
+			Expect(errors.As(result, &cfErr)).To(BeTrue())
+			Expect(cfErr.StatusCode).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("maps CloudFoundryHTTPError preserving status code", func() {
+			err := resource.CloudFoundryHTTPError{StatusCode: 503, Status: "Service Unavailable", Body: []byte("down")}
+			result := cf.MapCFClientError(err)
+			var cfErr *cf.CfError
+			Expect(errors.As(result, &cfErr)).To(BeTrue())
+			Expect(cfErr.StatusCode).To(Equal(503))
+		})
+
+		It("maps CloudFoundryErrors taking status from first error", func() {
+			err := resource.CloudFoundryErrors{Errors: []resource.CloudFoundryError{
+				{Code: 10010, Title: "CF-ResourceNotFound", Detail: "Not found"},
+				{Code: 10002, Title: "CF-NotAuthenticated", Detail: "No auth"},
+			}}
+			result := cf.MapCFClientError(err)
+			var cfErr *cf.CfError
+			Expect(errors.As(result, &cfErr)).To(BeTrue())
+			Expect(cfErr.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(cfErr.Errors).To(HaveLen(2))
+		})
+
+		It("returns original error if not a CF client error", func() {
+			err := errors.New("some random error")
+			result := cf.MapCFClientError(err)
+			Expect(result).To(Equal(err))
 		})
 	})
 })

--- a/scalingengine/server/scaling_handler.go
+++ b/scalingengine/server/scaling_handler.go
@@ -51,12 +51,17 @@ func (h *ScalingHandler) Scale(w http.ResponseWriter, r *http.Request, vars map[
 
 		var cfApiClientErrTypeProxy *cf.CfError
 		if errors.As(err, &cfApiClientErrTypeProxy) {
+			statusCode := cfApiClientErrTypeProxy.StatusCode
+			if statusCode == 0 {
+				statusCode = http.StatusInternalServerError
+			}
+
 			errorDescription, err := json.Marshal(cfApiClientErrTypeProxy)
 			if err != nil {
 				logger.Error("failed-to-serialize cf-api-error", err)
 			}
 
-			handlers.WriteJSONResponse(w, cfApiClientErrTypeProxy.StatusCode, models.ErrorResponse{
+			handlers.WriteJSONResponse(w, statusCode, models.ErrorResponse{
 				Code:    "Error on request to the cloud-controller via a cf-client",
 				Message: fmt.Sprintf("Error taking scaling action:\n%s", string(errorDescription))})
 		} else {


### PR DESCRIPTION
## Summary
- `MapCFClientError` created `CfError` without setting `StatusCode`, causing `WriteHeader(0)` panic on Go 1.22+ when the scaling handler forwarded it to the HTTP response
- Now maps CF error codes to proper HTTP status codes (10010→404, 10002→401, 10003→403) and handles `CloudFoundryHTTPError`
- Adds defensive guard in scaling handler: defaults to 500 if `StatusCode` is still 0

## Root Cause
When scalingengine receives a scale trigger for an app that was already deleted (race condition during test cleanup), the CF API returns `CF-ResourceNotFound`. The go-cfclient `CloudFoundryError` type doesn't carry HTTP status, so `MapCFClientError` left `StatusCode` at zero. The handler then called `WriteHeader(0)` which panics in Go 1.22+.

## Test plan
- [x] Added 8 unit tests for `MapCFClientError` covering all branches
- [x] All 57 cf package tests pass
- [ ] CI acceptance tests should no longer see 502s from scalingengine panics