### PR TITLE
ci(release): block draft release if acceptance tests failed on main

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -8,7 +8,31 @@ permissions:
   contents: write
 
 jobs:
+  check-ci:
+    runs-on: ubuntu-latest
+    name: Check acceptance tests passed on main
+    steps:
+      - name: Verify acceptance tests passed for this commit on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          conclusion=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --branch main \
+            --workflow "acceptance_tests_mta.yaml" \
+            --status completed \
+            --limit 50 \
+            --json conclusion,headSha \
+            --jq '.[] | select(.headSha == "${{ github.sha }}") | .conclusion' \
+            | head -1)
+          echo "Acceptance test conclusion for ${{ github.sha }}: ${conclusion}"
+          if [[ "${conclusion}" != "success" ]]; then
+            echo "Acceptance tests did not pass for commit ${{ github.sha }} (conclusion: ${conclusion:-not found}). Blocking release draft."
+            exit 1
+          fi
+
   create-draft-release:
+    needs: check-ci
     runs-on: ubuntu-latest
     name: Create draft release
     steps:

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -4,13 +4,14 @@ name: Create Draft Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   check-ci:
     runs-on: ubuntu-latest
     name: Check acceptance tests passed on main
+    permissions:
+      actions: read
     steps:
       - name: Verify acceptance tests passed for this commit on main
         env:
@@ -35,6 +36,8 @@ jobs:
     needs: check-ci
     runs-on: ubuntu-latest
     name: Create draft release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
- Release drafts could be triggered against commits where CI on main was failing, risking releases from a broken state
- Since #1141, `use_metricsgateway` differs between PR and main runs — main has been failing, yet nothing prevented drafting a release from those commits
- Add a gate that checks the exact commit being released passed acceptance tests before allowing the draft to proceed

## Changes
- `.github/workflows/release-draft.yaml`: add `check-ci` job that queries `acceptance_tests_mta.yaml` runs filtered by `headSha == github.sha`; `create-draft-release` now depends on it via `needs: check-ci`

## Testing
- [ ] Trigger `workflow_dispatch` on a commit where acceptance tests failed → `check-ci` should fail, draft blocked
- [ ] Trigger `workflow_dispatch` on a commit where acceptance tests passed → draft created normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)