### PR TITLE
Test default-handling of basic-authentication

### DIFF
--- a/api/config/parser.go
+++ b/api/config/parser.go
@@ -230,7 +230,8 @@ func (c *rawConfig) validate() error {
 		return fmt.Errorf("Configuration error: CatalogPath is empty")
 	}
 
-	validBasicAuthSwitches := []string{"on", "off", "only_existing_bindings"}
+	// We allow as well the configuration to be not set. "" is mapped to the default-value "on".
+	validBasicAuthSwitches := []string{"", "on", "off", "only_existing_bindings"}
 	if ba4cmCfgIsValid := slices.Contains(validBasicAuthSwitches, c.BasicAuthForCustomMetrics); !ba4cmCfgIsValid {
 		return fmt.Errorf("Configuration error: BasicAuthForCustomMetrics is invalid: \"%s\"", c.BasicAuthForCustomMetrics)
 	}

--- a/api/config/parser_internal_test.go
+++ b/api/config/parser_internal_test.go
@@ -411,6 +411,20 @@ var _ = Describe("toConfig credential helper and basic auth conversion", func() 
 
 	// --- basic_auth_for_custom_metrics tests ---
 
+	When("basic_auth_for_custom_metrics is not set", func() {
+		BeforeEach(func() {
+			conf.BasicAuthForCustomMetrics = ""
+		})
+
+		It("should succeed", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should map to the default-value (which is \"on\")", func() {
+			Expect(result.CustomMetricsAuthConfig).NotTo(BeNil())
+			Expect(result.CustomMetricsAuthConfig.BasicAuthHandling).To(Equal(BasicAuthHandlingOn))
+		})
+	})
+
 	When("basic_auth_for_custom_metrics is set to an invalid value", func() {
 		BeforeEach(func() {
 			conf.BasicAuthForCustomMetrics = "invalid_value"

--- a/metricsforwarder/config/parser.go
+++ b/metricsforwarder/config/parser.go
@@ -56,6 +56,8 @@ func toConfig(rawConfig rawConfig) (Config, error) {
 		}
 	case "default", "":
 		result.CredentialHelperConfig = models.BasicAuthHandlingNative{}
+	case "disabled":
+		result.CredentialHelperConfig = nil
 	}
 
 	return result, nil
@@ -163,6 +165,8 @@ func (c *rawConfig) validateCredHelperImpl() error {
 			msg := "CredHelperImpl is set to the default but there is a StoredProcedureConfig"
 			return errors.New(msg)
 		}
+	case "disabled":
+	// Nothing to validate if the credential helper is disabled.
 	default:
 		msg := fmt.Sprintf("CredHelperImpl is set to %s which is not a supported value", c.CredHelperImpl)
 		return errors.New(msg)

--- a/metricsforwarder/config/parser.go
+++ b/metricsforwarder/config/parser.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/configutil"
@@ -211,13 +212,16 @@ func loadVcapConfig(conf *rawConfig, vcapReader configutil.VCAPConfigurationRead
 
 	var basicAuthImplCfg *models.BasicAuthHandlingImplConfig
 	if conf.CredHelperImpl != "" {
-		var impl models.BasicAuthHandlingImplConfig
+		var impl models.BasicAuthHandlingImplConfig = nil
 		if conf.CredHelperImpl == "stored_procedure" && conf.StoredProcedureConfig != nil {
 			impl = models.BasicAuthHandlingStoredProc{Config: *conf.StoredProcedureConfig}
-		} else {
+			basicAuthImplCfg = &impl
+		} else if slices.Contains([]string{"", "default"}, conf.CredHelperImpl) {
 			impl = models.BasicAuthHandlingNative{}
+			basicAuthImplCfg = &impl
+		} else {
+			basicAuthImplCfg = nil
 		}
-		basicAuthImplCfg = &impl
 	}
 	if err := vcapReader.ConfigureDatabases(&conf.Db, basicAuthImplCfg); err != nil {
 		return err

--- a/metricsforwarder/config/parser_internal_test.go
+++ b/metricsforwarder/config/parser_internal_test.go
@@ -42,7 +42,6 @@ var _ = Describe("rawConfig validation", func() {
 
 		conf.CredHelperImpl = "default"
 	})
-
 	JustBeforeEach(func() {
 		err = conf.validate()
 	})
@@ -52,7 +51,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
-
 	When("syslog is available", func() {
 		BeforeEach(func() {
 			conf.SyslogConfig = SyslogConfig{
@@ -101,7 +99,6 @@ var _ = Describe("rawConfig validation", func() {
 			})
 		})
 	})
-
 	When("policy db url is not set", func() {
 		BeforeEach(func() {
 			conf.Db[db.PolicyDb] = db.DatabaseConfig{URL: ""}
@@ -111,7 +108,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).To(MatchError(MatchRegexp("configuration error: Policy DB url is empty")))
 		})
 	})
-
 	When("binding db url is not set", func() {
 		BeforeEach(func() {
 			conf.Db[db.BindingDb] = db.DatabaseConfig{URL: ""}
@@ -121,7 +117,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).To(MatchError(MatchRegexp("configuration error: Binding DB url is empty")))
 		})
 	})
-
 	When("Loggregator CACert is not set", func() {
 		BeforeEach(func() {
 			conf.LoggregatorConfig.TLS.CACertFile = ""
@@ -131,7 +126,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).To(MatchError(MatchRegexp("Loggregator CACert is empty")))
 		})
 	})
-
 	When("Loggregator ClientCert is not set", func() {
 		BeforeEach(func() {
 			conf.LoggregatorConfig.TLS.CertFile = ""
@@ -141,7 +135,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).To(MatchError(MatchRegexp("Loggregator ClientCert is empty")))
 		})
 	})
-
 	When("Loggregator ClientKey is not set", func() {
 		BeforeEach(func() {
 			conf.LoggregatorConfig.TLS.KeyFile = ""
@@ -151,7 +144,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).To(MatchError(MatchRegexp("Loggregator ClientKey is empty")))
 		})
 	})
-
 	When("rate_limit.max_amount is <= zero", func() {
 		BeforeEach(func() {
 			conf.RateLimit.MaxAmount = 0
@@ -161,7 +153,6 @@ var _ = Describe("rawConfig validation", func() {
 			Expect(err).To(MatchError(MatchRegexp("RateLimit.MaxAmount is less than or equal to zero")))
 		})
 	})
-
 	When("rate_limit.valid_duration is <= 0 ns", func() {
 		BeforeEach(func() {
 			conf.RateLimit.ValidDuration = 0 * time.Nanosecond
@@ -220,6 +211,18 @@ var _ = Describe("toConfig credential helper conversion", func() {
 
 		It("should set CredentialHelperConfig to BasicAuthHandlingNative", func() {
 			Expect(result.CredentialHelperConfig).To(BeAssignableToTypeOf(models.BasicAuthHandlingNative{}))
+		})
+	})
+	When("cred_helper_impl is set to 'disabled'", func() {
+		BeforeEach(func() {
+			conf.CredHelperImpl = "disabled"
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should set CredentialHelperConfig to nil", func() {
+			Expect(result.CredentialHelperConfig).To(BeNil())
 		})
 	})
 	When("cred_helper_impl is empty (not set)", func() {


### PR DESCRIPTION
This PR adds a test for the default-handling of basic-authentication for custom-metrics which has been proposed in <https://github.com/cloudfoundry/app-autoscaler/pull/1168#discussion_r3330986351> on the review of #1168.

It furthermore makes the "off"-case reachable for the metricsforwarder and adds a test accordingly.