### PR TITLE
ci: add one-off workflow to create CF org manager user

### DIFF
--- a/.github/workflows/create-org-manager-user.yaml
+++ b/.github/workflows/create-org-manager-user.yaml
@@ -3,15 +3,11 @@ name: Create Org Manager User
 on:
   workflow_dispatch:
     inputs:
-      autoscaler_org:
-        required: true
-        type: string
-        description: "CF org to grant OrgManager role in"
-      existing_organization:
+      org:
         required: false
         type: string
         default: "SAP_autoscaler_tests_OSS"
-        description: "Additional CF org to grant OrgManager role in (if different from autoscaler_org)"
+        description: "CF org to create the org manager user in"
 
 defaults:
   run:
@@ -20,7 +16,7 @@ defaults:
 env:
   AUTOSCALER_DIR: "${{ github.workspace }}/app-autoscaler"
   BBL_STATE_PATH: "${{ github.workspace }}/bbl/bbl-state"
-  AUTOSCALER_ORG: "${{ inputs.autoscaler_org }}"
+  AUTOSCALER_ORG: "${{ inputs.org }}"
 
 jobs:
   create_org_manager_user:
@@ -51,7 +47,6 @@ jobs:
 
       - name: Create org manager user and store credentials
         env:
-          EXISTING_ORGANIZATION: ${{ inputs.existing_organization }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make --directory="${AUTOSCALER_DIR}" create-org-manager-user

--- a/.github/workflows/create-org-manager-user.yaml
+++ b/.github/workflows/create-org-manager-user.yaml
@@ -1,0 +1,57 @@
+name: Create Org Manager User
+
+on:
+  workflow_dispatch:
+    inputs:
+      autoscaler_org:
+        required: true
+        type: string
+        description: "CF org to grant OrgManager role in"
+      existing_organization:
+        required: false
+        type: string
+        default: ""
+        description: "Additional CF org to grant OrgManager role in (if different from autoscaler_org)"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  AUTOSCALER_DIR: "${{ github.workspace }}/app-autoscaler"
+  BBL_STATE_PATH: "${{ github.workspace }}/bbl/bbl-state"
+  AUTOSCALER_ORG: "${{ inputs.autoscaler_org }}"
+
+jobs:
+  create_org_manager_user:
+    name: Create Org Manager User
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          path: app-autoscaler
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
+        with:
+          enable-cache: 'true'
+          project-path: "${AUTOSCALER_DIR}"
+
+      - name: Make devbox shellenv available
+        run: |
+          cd "${AUTOSCALER_DIR}"
+          eval "$(devbox shellenv)"
+          printenv >> "$GITHUB_ENV"
+
+      - name: Setup environment
+        uses: ./app-autoscaler/.github/actions/setup-environment
+        with:
+          ssh-key: ${{ secrets.BBL_SSH_KEY }}
+
+      - name: Create org manager user and store credentials
+        env:
+          EXISTING_ORGANIZATION: ${{ inputs.existing_organization }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make --directory="${AUTOSCALER_DIR}" create-org-manager-user

--- a/.github/workflows/create-org-manager-user.yaml
+++ b/.github/workflows/create-org-manager-user.yaml
@@ -47,6 +47,6 @@ jobs:
 
       - name: Create org manager user and store credentials
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.APP_AUTOSCALER_CI_TOKEN }}
         run: |
           make --directory="${AUTOSCALER_DIR}" create-org-manager-user

--- a/.github/workflows/create-org-manager-user.yaml
+++ b/.github/workflows/create-org-manager-user.yaml
@@ -10,7 +10,7 @@ on:
       existing_organization:
         required: false
         type: string
-        default: ""
+        default: "SAP_autoscaler_tests_OSS"
         description: "Additional CF org to grant OrgManager role in (if different from autoscaler_org)"
 
 defaults:

--- a/scripts/create-org-manager-user.sh
+++ b/scripts/create-org-manager-user.sh
@@ -20,12 +20,6 @@ function create_org_manager_user() {
 	cf create-user "${AUTOSCALER_ORG_MANAGER_USER}" "${password}"
 	cf set-org-role "${AUTOSCALER_ORG_MANAGER_USER}" "${AUTOSCALER_ORG}" OrgManager
 
-	local existing_org="${EXISTING_ORGANIZATION:-}"
-	if [[ -n "${existing_org}" && "${existing_org}" != "${AUTOSCALER_ORG}" ]]; then
-		log "Granting OrgManager role in existing org: ${existing_org}"
-		cf set-org-role "${AUTOSCALER_ORG_MANAGER_USER}" "${existing_org}" OrgManager
-	fi
-
 	local repo
 	repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
 

--- a/scripts/create-org-manager-user.sh
+++ b/scripts/create-org-manager-user.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+# shellcheck source=scripts/vars.source.sh
+source "${script_dir}/vars.source.sh"
+# shellcheck source=scripts/common.sh
+source "${script_dir}/common.sh"
+
+function create_org_manager_user() {
+	step "Creating org manager CF user"
+	log "Organization: ${AUTOSCALER_ORG}"
+
+	cf_target "${AUTOSCALER_ORG}" "${AUTOSCALER_SPACE}"
+
+	local password
+	password="$(openssl rand -base64 32)"
+
+	cf delete-user -f "${AUTOSCALER_ORG_MANAGER_USER}" || true
+	cf create-user "${AUTOSCALER_ORG_MANAGER_USER}" "${password}"
+	cf set-org-role "${AUTOSCALER_ORG_MANAGER_USER}" "${AUTOSCALER_ORG}" OrgManager
+
+	local existing_org="${EXISTING_ORGANIZATION:-}"
+	if [[ -n "${existing_org}" && "${existing_org}" != "${AUTOSCALER_ORG}" ]]; then
+		log "Granting OrgManager role in existing org: ${existing_org}"
+		cf set-org-role "${AUTOSCALER_ORG_MANAGER_USER}" "${existing_org}" OrgManager
+	fi
+
+	local repo
+	repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+
+	log "Writing username to GitHub repo variable AUTOSCALER_ORG_MANAGER_USER"
+	gh variable set AUTOSCALER_ORG_MANAGER_USER --body "${AUTOSCALER_ORG_MANAGER_USER}" --repo "${repo}"
+
+	log "Writing password to GitHub repo secret AUTOSCALER_ORG_MANAGER_PASSWORD"
+	gh secret set AUTOSCALER_ORG_MANAGER_PASSWORD --body "${password}" --repo "${repo}"
+
+	step "Org manager user created and credentials stored!"
+}
+
+function main() {
+	bbl_login
+	cf_admin_login
+	create_org_manager_user
+	return 0
+}
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"


### PR DESCRIPTION
## What and why

Bootstrapping the CF org manager user currently requires running a script manually with admin credentials. This adds a `workflow_dispatch` workflow to do it once in CI, storing the credentials in GitHub repo secret/var so subsequent per-PR runs no longer need CF admin access for space role setup.

## Changes

**One-off bootstrap workflow** — `create-org-manager-user.yaml` runs on demand via `workflow_dispatch`. It creates the CF user with admin credentials, grants `OrgManager` role, then writes the username to a GitHub repo variable (`AUTOSCALER_ORG_MANAGER_USER`) and the password to a GitHub repo secret (`AUTOSCALER_ORG_MANAGER_PASSWORD`) using `APP_AUTOSCALER_CI_TOKEN`. The `org` input defaults to `SAP_autoscaler_tests_OSS`.

**Bootstrap script** — `scripts/create-org-manager-user.sh` handles the CF user creation and `gh` secret/var writes. Uses `openssl rand` to generate the password rather than credhub, removing the credhub dependency for this step.

**Makefile target** — `create-org-manager-user` target added to invoke the script.

## How to use after merge

Trigger via **Actions → Create Org Manager User → Run workflow**. The `org` input defaults to `SAP_autoscaler_tests_OSS` — just hit run.

## Test plan

- [ ] Trigger workflow after merge
- [ ] Verify `AUTOSCALER_ORG_MANAGER_USER` GitHub variable is set
- [ ] Verify `AUTOSCALER_ORG_MANAGER_PASSWORD` GitHub secret is updated
- [ ] Verify acceptance test PR run succeeds with space role setup using stored credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)