### PR TITLE
ci: add create-org-manager-user Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,6 +560,10 @@ deploy-register-cf:
 deploy-cleanup:
 	DEBUG="${DEBUG}" ./scripts/cleanup-autoscaler.sh
 
+.PHONY: create-org-manager-user
+create-org-manager-user:
+	DEBUG="${DEBUG}" ./scripts/create-org-manager-user.sh
+
 .PHONY: deploy-apps
 deploy-apps:
 	DEBUG="${DEBUG}" ./scripts/deploy-apps.sh


### PR DESCRIPTION
Missing target needed by the create-org-manager-user workflow (merged in #1252).