### PR TITLE
fix(tls): switch from internal to external service defaults

### DIFF
--- a/models/security.go
+++ b/models/security.go
@@ -25,13 +25,13 @@ func (t *TLSCerts) CreateClientConfig() (*tls.Config, error) {
 	}
 
 	if t.CACertFile != "" && t.CertFile == "" && t.KeyFile == "" {
-		clientTls := tlsconfig.Build(tlsconfig.WithInternalServiceDefaults())
+		clientTls := tlsconfig.Build(tlsconfig.WithExternalServiceDefaults())
 		return clientTls.Client(tlsconfig.WithAuthorityFromFile(t.CACertFile))
 	}
 
 	if t.CertFile != "" && t.KeyFile != "" {
 		clientTls := tlsconfig.Build(
-			tlsconfig.WithInternalServiceDefaults(),
+			tlsconfig.WithExternalServiceDefaults(),
 			tlsconfig.WithIdentityFromFile(t.CertFile, t.KeyFile))
 		if t.CACertFile != "" {
 			return clientTls.Client(tlsconfig.WithAuthorityFromFile(t.CACertFile))
@@ -45,7 +45,7 @@ func (t *TLSCerts) CreateClientConfig() (*tls.Config, error) {
 func (t *TLSCerts) CreateServerConfig() (*tls.Config, error) {
 	if t != nil && t.CertFile != "" && t.KeyFile != "" {
 		serverTls := tlsconfig.Build(
-			tlsconfig.WithInternalServiceDefaults(),
+			tlsconfig.WithExternalServiceDefaults(),
 			tlsconfig.WithIdentityFromFile(t.CertFile, t.KeyFile))
 		if t.CACertFile != "" {
 			return serverTls.Server(tlsconfig.WithClientAuthenticationFromFile(t.CACertFile))


### PR DESCRIPTION
# Issue

As discussed in the CF Slack thread [1], `code.cloudfoundry.org/tlsconfig`'s
`WithInternalServiceDefaults` does not allow ECC certificates.

The use of `WithInternalServiceDefaults` is a holdover from BOSH-era
deployments where microservices communicated directly. In the CF deployment
model, traffic flows through CF ingress (Gorouter, load balancers, reverse
proxies), so `WithExternalServiceDefaults` is the appropriate choice.

[1] https://cloudfoundry.slack.com/archives/C0RUU7GBZ/p1781197261596289?thread_ts=1781181057.598879&cid=C0RUU7GBZ

# Fix

Switch `WithInternalServiceDefaults` to `WithExternalServiceDefaults` in
`models/security.go` for both client and server TLS configs.
