### PR TITLE
fix: bind postgres security group globally

### DIFF
--- a/ci/infrastructure/scripts/deploy-postgres.sh
+++ b/ci/infrastructure/scripts/deploy-postgres.sh
@@ -42,9 +42,31 @@ function deploy () {
     ${bosh_deploy_opts}
 }
 
+function setup_postgres_security_group() {
+  postgres_ip="$(credhub get -n /bosh-autoscaler/postgres/postgres_host_or_ip --quiet)"
+
+  security_group_json_path="$(mktemp)"
+  cat <<EOF > "${security_group_json_path}"
+[
+  {
+    "protocol": "tcp",
+    "destination": "${postgres_ip}/32",
+    "ports": "5524",
+    "description": "allow egress to the internal postgres IP"
+  }
+]
+EOF
+
+  cf_login "${system_domain}"
+  cf create-security-group postgres "${security_group_json_path}" || true
+  cf update-security-group postgres "${security_group_json_path}"
+  cf bind-security-group postgres --global
+}
+
 load_bbl_vars
 find_or_upload_stemcell_from "${deployment_manifest}"
 
 upload_release "${release_dir}"
 deploy
+setup_postgres_security_group
 


### PR DESCRIPTION
## What

Bind the postgres security group with `--global` flag in `deploy-postgres.sh` so it applies to all orgs/spaces, including future ones.

## Why

Space-scoped security group bindings are lost when spaces are deleted and recreated. This forces acceptance test workflows to explicitly re-bind after space recreation. A global binding eliminates that need — new spaces automatically inherit it.

## Trade-off

Every space on the foundation gets postgres network egress access. Acceptable since this is a dedicated autoscaler test foundation where all apps need DB access.

## Changes

- `ci/infrastructure/scripts/deploy-postgres.sh`: Added `setup_postgres_security_group()` that creates/updates the postgres security group and binds it globally.