### PR TITLE
fix: use cf bind-running-security-group for global binding

### DIFF
--- a/ci/infrastructure/scripts/deploy-postgres.sh
+++ b/ci/infrastructure/scripts/deploy-postgres.sh
@@ -60,7 +60,7 @@ EOF
   cf_login "${system_domain}"
   cf create-security-group postgres "${security_group_json_path}" || true
   cf update-security-group postgres "${security_group_json_path}"
-  cf bind-security-group postgres --global
+  cf bind-running-security-group postgres
 }
 
 load_bbl_vars


### PR DESCRIPTION
## Problem

PR #1262 introduced `cf bind-security-group postgres --global` but `--global` flag doesn't exist on `cf bind-security-group`.

## Fix

Use the correct command: `cf bind-running-security-group postgres`

This sets the postgres security group as a platform-wide running default — applies to all orgs/spaces including future ones.