### PR TITLE
fix: update Spring Boot to 3.5.15 and transitive dependencies

### DIFF
--- a/dbtasks/pom.xml
+++ b/dbtasks/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.14</version>
+    <version>3.5.15</version>
     <relativePath/>
   </parent>
 

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.15</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary

Updates Spring Boot from 3.5.14 to 3.5.15 and resolves issues in transitive dependencies (Spring Data Commons and Logback) affecting the Java Scheduler component.

## Problem

The following outdated dependencies were detected in the Java components:

| Component | Current Version |
|-----------|----------------|
| Spring Data Commons | 3.5.11 |
| Logback | 1.5.32 |
| Spring Boot | 3.5.14 |

## Solution

Update Spring Boot from 3.5.14 to 3.5.15, which transitively updates all related dependencies:
- **Spring Data Commons**: 3.5.11 → 3.5.12
- **Logback Classic**: 1.5.32 → 1.5.34
- **Spring Boot**: 3.5.14 → 3.5.15