### PR TITLE
chore(deps): bump Spring Boot to 4.1 

### DIFF
--- a/dbtasks/pom.xml
+++ b/dbtasks/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.15</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
 
@@ -27,6 +27,9 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
+      <!-- Pinned to latest 4.x: Liquibase 5+ uses the Functional Source License (FSL),
+           which is incompatible with open-source distribution. Renovate updates are
+           disabled for this package (see renovate.json). -->
       <version>4.33.0</version>
     </dependency>
     <dependency>
@@ -37,23 +40,14 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.11</version>
     </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>9.7.0</version>
-    </dependency>
-    <!-- Spring Boot -->
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -62,7 +56,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.20.0</version>
     </dependency>
   </dependencies>
 
@@ -77,10 +70,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.15.0</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
 

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.15</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
 
@@ -28,10 +28,6 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
@@ -42,6 +38,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web-services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>2.3.7</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -56,14 +58,42 @@
             <artifactId>spring-boot-starter-quartz</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-annotations</artifactId>
-            <version>1.6.16</version>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-annotations-jakarta</artifactId>
+          <version>2.2.41</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-            <scope>provided</scope>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <!--
+          Spring Boot 4 split the embedded-Tomcat runtime from the autoconfig glue.
+          spring-boot-starter-tomcat (provided) keeps tomcat-embed-* off the WAR
+          classpath so the external Tomcat wins, but spring-boot-tomcat carries
+          autoconfig classes (e.g. TomcatServletWebServerFactory) that Spring's
+          classpath scan still touches at startup — so it must ship in WEB-INF/lib.
+          See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes
+        -->
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-tomcat</artifactId>
+          <exclusions>
+            <!-- External Tomcat (the Java buildpack's) supplies tomcat-embed-core.
+                 Shipping our own would conflict at runtime. -->
+            <exclusion>
+              <groupId>org.apache.tomcat.embed</groupId>
+              <artifactId>tomcat-embed-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-gson</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-webclient</artifactId>
         </dependency>
         <!-- Note: Explicitly specified as the respective jar is not showing in
             the maven dependencies -->
@@ -74,12 +104,10 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
@@ -88,23 +116,30 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${io.prometheus.simpleclient.version}</version>
         </dependency>
         <!-- Hotspot JVM metrics-->
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_hotspot</artifactId>
-            <version>${io.prometheus.simpleclient.version}</version>
         </dependency>
         <!-- Exposition HTTPServer-->
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_httpserver</artifactId>
-            <version>${io.prometheus.simpleclient.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-validation-test</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-restclient-test</artifactId>
+          <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -121,6 +156,16 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/SchedulerApplication.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/SchedulerApplication.java
@@ -8,18 +8,18 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
-import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration;
 import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
-import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.boot.autoconfigure.transaction.jta.JtaAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.data.jpa.autoconfigure.DataJpaRepositoriesAutoConfiguration;
+import org.springframework.boot.gson.autoconfigure.GsonAutoConfiguration;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.JdbcTemplateAutoConfiguration;
+import org.springframework.boot.transaction.jta.autoconfigure.JtaAutoConfiguration;
+import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
 import org.springframework.context.event.EventListener;
 
 @ConfigurationPropertiesScan(basePackageClasses = MetricsConfig.class)
@@ -37,7 +37,7 @@ import org.springframework.context.event.EventListener;
       JdbcTemplateAutoConfiguration.class,
       JtaAutoConfiguration.class,
       HibernateJpaAutoConfiguration.class,
-      JpaRepositoriesAutoConfiguration.class
+      DataJpaRepositoriesAutoConfiguration.class
     })
 public class SchedulerApplication {
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/beanPostProcessor/DatasourceBeanPostProcessor.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/beanPostProcessor/DatasourceBeanPostProcessor.java
@@ -22,13 +22,11 @@ public class DatasourceBeanPostProcessor implements BeanPostProcessor {
 
   @Override
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-    if (bean instanceof DataSource) {
-      DataSource ds = (DataSource) bean;
+    if (bean instanceof DataSource ds) {
       Connection con = null;
       try {
         // Log datasource details for debugging
-        if (ds instanceof HikariDataSource) {
-          HikariDataSource hikariDs = (HikariDataSource) ds;
+        if (ds instanceof HikariDataSource hikariDs) {
           logger.info(
               "Attempting to connect to datasource '{}' with URL: {}",
               beanName,

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/CfHttpConfiguration.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/CfHttpConfiguration.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.catalina.connector.Connector;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +27,7 @@ public class CfHttpConfiguration {
       Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
       connector.setPort(port);
       connector.setSecure(false);
-      factory.addAdditionalTomcatConnectors(connector);
+      factory.addAdditionalConnectors(connector);
     };
   }
 }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/CloudFoundryConfigurationProcessor.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/CloudFoundryConfigurationProcessor.java
@@ -1,7 +1,5 @@
 package org.cloudfoundry.autoscaler.scheduler.conf;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -12,6 +10,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class CloudFoundryConfigurationProcessor implements EnvironmentPostProcessor, Ordered {
   private static final Logger logger =
@@ -108,8 +108,7 @@ public class CloudFoundryConfigurationProcessor implements EnvironmentPostProces
 
       // Extract organization_id
       Object organizationId = vcapApp.get("organization_id");
-      if (organizationId instanceof String && !((String) organizationId).trim().isEmpty()) {
-        String orgGuid = (String) organizationId;
+      if (organizationId instanceof String orgGuid && !orgGuid.trim().isEmpty()) {
         logger.info(
             "Setting cfserver.validOrgGuid from VCAP_APPLICATION organization_id: {}", orgGuid);
         orgSpaceMap.put("validOrgGuid", orgGuid);
@@ -120,8 +119,7 @@ public class CloudFoundryConfigurationProcessor implements EnvironmentPostProces
 
       // Extract space_id
       Object spaceId = vcapApp.get("space_id");
-      if (spaceId instanceof String && !((String) spaceId).trim().isEmpty()) {
-        String spaceGuid = (String) spaceId;
+      if (spaceId instanceof String spaceGuid && !spaceGuid.trim().isEmpty()) {
         logger.info(
             "Setting cfserver.validSpaceGuid from VCAP_APPLICATION space_id: {}", spaceGuid);
         orgSpaceMap.put("validSpaceGuid", spaceGuid);
@@ -313,7 +311,7 @@ public class CloudFoundryConfigurationProcessor implements EnvironmentPostProces
     } else if (hostname != null && portObj != null && dbname != null) {
       // Build from individual components
       String port = portObj.toString();
-      baseUrl = String.format("jdbc:postgresql://%s:%s/%s", hostname, port, dbname);
+      baseUrl = "jdbc:postgresql://%s:%s/%s".formatted(hostname, port, dbname);
     }
 
     if (baseUrl == null) {

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfig.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfig.java
@@ -5,8 +5,9 @@ import java.util.Properties;
 import javax.sql.DataSource;
 import org.cloudfoundry.autoscaler.scheduler.beanPostProcessor.DatasourceBeanPostProcessor;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -68,6 +69,7 @@ public class DataSourceConfig {
   }
 
   @Bean
+  @DependsOnDatabaseInitialization
   @Primary
   @Qualifier("primary")
   public JpaTransactionManager transactionManager(
@@ -79,6 +81,7 @@ public class DataSourceConfig {
   }
 
   @Bean
+  @DependsOnDatabaseInitialization
   @Qualifier("policy")
   public JpaTransactionManager policyDbTransactionManager(
       @Qualifier("policy") DataSource policyDataSource) {

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/HealthConfig.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/HealthConfig.java
@@ -5,6 +5,7 @@ import org.cloudfoundry.autoscaler.scheduler.health.DbStatusCollector;
 import org.cloudfoundry.autoscaler.scheduler.health.HealthExporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 public class HealthConfig {
 
   @Bean
+  @DependsOnDatabaseInitialization
   public DbStatusCollector dbStatusCollector(
       @Qualifier("primary") DataSource primaryDs, @Qualifier("policy") DataSource policyDs) {
     DbStatusCollector dbStatusCollector = new DbStatusCollector();

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/QuartzConfig.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/QuartzConfig.java
@@ -4,7 +4,8 @@ import java.util.Properties;
 import javax.sql.DataSource;
 import org.cloudfoundry.autoscaler.scheduler.quartz.QuartzJobFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.quartz.QuartzProperties;
+import org.springframework.boot.quartz.autoconfigure.QuartzProperties;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,7 @@ public class QuartzConfig {
   }
 
   @Bean
+  @DependsOnDatabaseInitialization
   public SchedulerFactoryBean quartzScheduler(@Qualifier("primary") DataSource primaryDataSource)
       throws Exception {
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/RestClientConfig.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/RestClientConfig.java
@@ -10,7 +10,6 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.HttpsSupport;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.util.Timeout;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslBundles;
@@ -25,7 +24,6 @@ import org.springframework.web.client.RestTemplate;
 public class RestClientConfig {
   private final SSLContext sslContext;
 
-  @Autowired
   public RestClientConfig(SslBundles sslBundles) {
     SslBundle sslBundle = sslBundles.getBundle("scalingengine");
     this.sslContext = sslBundle.createSslContext();

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/dao/ActiveScheduleDaoImpl.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/dao/ActiveScheduleDaoImpl.java
@@ -6,11 +6,13 @@ import javax.sql.DataSource;
 import org.cloudfoundry.autoscaler.scheduler.entity.ActiveScheduleEntity;
 import org.cloudfoundry.autoscaler.scheduler.util.error.DatabaseValidationException;
 import org.hibernate.type.SqlTypes;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 import org.springframework.stereotype.Repository;
 
+@DependsOnDatabaseInitialization
 @Repository("activeScheduleDao")
 public class ActiveScheduleDaoImpl extends JdbcDaoSupport implements ActiveScheduleDao {
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/dao/GenericDaoImpl.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/dao/GenericDaoImpl.java
@@ -1,12 +1,12 @@
 package org.cloudfoundry.autoscaler.scheduler.dao;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.cloudfoundry.autoscaler.scheduler.util.error.DatabaseValidationException;
+import org.hibernate.Session;
 
 class GenericDaoImpl<T> implements GenericDao<T> {
 
-  @PersistenceContext EntityManager entityManager;
+  @PersistenceContext Session entityManager;
   private Class<T> entityClass;
 
   GenericDaoImpl() {}

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/dao/PolicyJsonDaoImpl.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/dao/PolicyJsonDaoImpl.java
@@ -4,10 +4,12 @@ import jakarta.annotation.Resource;
 import java.util.List;
 import javax.sql.DataSource;
 import org.cloudfoundry.autoscaler.scheduler.entity.PolicyJsonEntity;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+@DependsOnDatabaseInitialization
 @Repository("policyJsonDao")
 public class PolicyJsonDaoImpl extends JdbcDaoSupport implements PolicyJsonDao {
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/ActiveScheduleEntity.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/ActiveScheduleEntity.java
@@ -2,13 +2,12 @@ package org.cloudfoundry.autoscaler.scheduler.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.springframework.jdbc.core.RowMapper;
 
-@ApiModel
+@Schema
 public class ActiveScheduleEntity implements RowMapper<ActiveScheduleEntity> {
 
   @JsonIgnore private Long id;
@@ -19,15 +18,15 @@ public class ActiveScheduleEntity implements RowMapper<ActiveScheduleEntity> {
 
   @JsonIgnore private Long startJobIdentifier;
 
-  @ApiModelProperty(required = true, position = 1)
+  @Schema(required = true)
   @JsonProperty(value = "instance_min_count")
   private Integer instanceMinCount;
 
-  @ApiModelProperty(required = true, position = 2)
+  @Schema(required = true)
   @JsonProperty(value = "instance_max_count")
   private Integer instanceMaxCount;
 
-  @ApiModelProperty(position = 3)
+  @Schema
   @JsonProperty(value = "initial_min_instance_count")
   private Integer initialMinInstanceCount;
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/BitsetUserType.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/BitsetUserType.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.usertype.UserType;
 
 /**
@@ -20,10 +21,7 @@ public class BitsetUserType implements UserType<int[]> {
 
   @Override
   public int[] nullSafeGet(
-      ResultSet resultSet,
-      int columnIndex,
-      SharedSessionContractImplementor sharedSessionContractImplementor,
-      Object o)
+      ResultSet resultSet, int columnIndex, WrapperOptions sharedSessionContractImplementor)
       throws SQLException {
     int value = resultSet.getInt(columnIndex);
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/RecurringScheduleEntity.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/RecurringScheduleEntity.java
@@ -1,10 +1,7 @@
 package org.cloudfoundry.autoscaler.scheduler.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQuery;
@@ -19,8 +16,10 @@ import org.cloudfoundry.autoscaler.scheduler.util.DateSerializer;
 import org.cloudfoundry.autoscaler.scheduler.util.TimeDeserializer;
 import org.cloudfoundry.autoscaler.scheduler.util.TimeSerializer;
 import org.hibernate.annotations.Type;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
-@ApiModel
+@Schema
 @Entity
 @Table(name = "app_scaling_recurring_schedule")
 @NamedQuery(
@@ -31,11 +30,7 @@ import org.hibernate.annotations.Type;
     query = RecurringScheduleEntity.jpql_findDistinctAppIdAndGuidFromRecurringSchedule)
 public class RecurringScheduleEntity extends ScheduleEntity {
 
-  @ApiModelProperty(
-      example = DateHelper.TIME_FORMAT,
-      dataType = "java.lang.String",
-      required = true,
-      position = 3)
+  @Schema(example = DateHelper.TIME_FORMAT, type = "java.lang.String", required = true)
   @JsonDeserialize(using = TimeDeserializer.class)
   @JsonSerialize(using = TimeSerializer.class)
   @NotNull
@@ -43,11 +38,7 @@ public class RecurringScheduleEntity extends ScheduleEntity {
   @JsonProperty(value = "start_time")
   private LocalTime startTime;
 
-  @ApiModelProperty(
-      example = DateHelper.TIME_FORMAT,
-      dataType = "java.lang.String",
-      required = true,
-      position = 4)
+  @Schema(example = DateHelper.TIME_FORMAT, type = "java.lang.String", required = true)
   @JsonDeserialize(using = TimeDeserializer.class)
   @JsonSerialize(using = TimeSerializer.class)
   @NotNull
@@ -55,27 +46,27 @@ public class RecurringScheduleEntity extends ScheduleEntity {
   @JsonProperty(value = "end_time")
   private LocalTime endTime;
 
-  @ApiModelProperty(example = DateHelper.DATE_FORMAT, position = 1)
+  @Schema(example = DateHelper.DATE_FORMAT)
   @JsonDeserialize(using = DateDeserializer.class)
   @JsonSerialize(using = DateSerializer.class)
   @Column(name = "start_date")
   @JsonProperty(value = "start_date")
   private LocalDate startDate;
 
-  @ApiModelProperty(example = DateHelper.DATE_FORMAT, position = 2)
+  @Schema(example = DateHelper.DATE_FORMAT)
   @JsonDeserialize(using = DateDeserializer.class)
   @JsonSerialize(using = DateSerializer.class)
   @Column(name = "end_date")
   @JsonProperty(value = "end_date")
   private LocalDate endDate;
 
-  @ApiModelProperty(example = "[2, 3, 4, 5]", hidden = true)
+  @Schema(example = "[2, 3, 4, 5]", hidden = true)
   @Type(value = org.cloudfoundry.autoscaler.scheduler.entity.BitsetUserType.class)
   @Column(name = "days_of_week")
   @JsonProperty(value = "days_of_week")
   private int[] daysOfWeek;
 
-  @ApiModelProperty(example = "[10, 20, 25]", position = 6)
+  @Schema(example = "[10, 20, 25]")
   @Type(value = org.cloudfoundry.autoscaler.scheduler.entity.BitsetUserType.class)
   @Column(name = "days_of_month")
   @JsonProperty(value = "days_of_month")

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/ScheduleEntity.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/ScheduleEntity.java
@@ -1,8 +1,7 @@
 package org.cloudfoundry.autoscaler.scheduler.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -10,58 +9,58 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
 
-@ApiModel
+@Schema
 @MappedSuperclass
 public class ScheduleEntity {
 
-  @ApiModelProperty(hidden = true)
+  @Schema(hidden = true)
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "schedule_id")
   private Long id;
 
-  @ApiModelProperty(hidden = true)
+  @Schema(hidden = true)
   @NotNull
   @JsonProperty(value = "app_id")
   @Column(name = "app_id")
   private String appId;
 
-  @ApiModelProperty(hidden = true)
+  @Schema(hidden = true)
   @NotNull
   @JsonProperty(value = "timezone")
   @Column(name = "timezone")
   private String timeZone;
 
-  @ApiModelProperty(hidden = true)
+  @Schema(hidden = true)
   @NotNull
   @Column(name = "default_instance_min_count")
   @JsonProperty(value = "default_instance_min_count")
   private Integer defaultInstanceMinCount;
 
-  @ApiModelProperty(hidden = true)
+  @Schema(hidden = true)
   @NotNull
   @Column(name = "default_instance_max_count")
   @JsonProperty(value = "default_instance_max_count")
   private Integer defaultInstanceMaxCount;
 
-  @ApiModelProperty(required = true, position = 10)
+  @Schema(required = true)
   @NotNull
   @Column(name = "instance_min_count")
   @JsonProperty(value = "instance_min_count")
   private Integer instanceMinCount;
 
-  @ApiModelProperty(required = true, position = 11)
+  @Schema(required = true)
   @NotNull
   @Column(name = "instance_max_count")
   @JsonProperty(value = "instance_max_count")
   private Integer instanceMaxCount;
 
-  @ApiModelProperty(required = true, position = 12)
+  @Schema(required = true)
   @Column(name = "initial_min_instance_count")
   @JsonProperty(value = "initial_min_instance_count")
   private Integer initialMinInstanceCount;
 
-  @ApiModelProperty(required = true, position = 13)
+  @Schema(required = true)
   @Column(name = "guid")
   @JsonProperty(value = "guid")
   private String guid;

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/SpecificDateScheduleEntity.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/entity/SpecificDateScheduleEntity.java
@@ -2,10 +2,7 @@ package org.cloudfoundry.autoscaler.scheduler.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQuery;
@@ -15,8 +12,10 @@ import java.time.LocalDateTime;
 import org.cloudfoundry.autoscaler.scheduler.util.DateHelper;
 import org.cloudfoundry.autoscaler.scheduler.util.DateTimeDeserializer;
 import org.cloudfoundry.autoscaler.scheduler.util.DateTimeSerializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
-@ApiModel
+@Schema
 @Entity
 @Table(name = "app_scaling_specific_date_schedule")
 @NamedQuery(
@@ -27,7 +26,7 @@ import org.cloudfoundry.autoscaler.scheduler.util.DateTimeSerializer;
     query = SpecificDateScheduleEntity.jpql_findDistinctAppIdAndGuidFromSpecificDateSchedule)
 public class SpecificDateScheduleEntity extends ScheduleEntity {
 
-  @ApiModelProperty(example = DateHelper.DATE_TIME_FORMAT, required = true, position = 1)
+  @Schema(example = DateHelper.DATE_TIME_FORMAT, required = true)
   @JsonFormat(pattern = DateHelper.DATE_TIME_FORMAT)
   @JsonDeserialize(using = DateTimeDeserializer.class)
   @JsonSerialize(using = DateTimeSerializer.class)
@@ -36,7 +35,7 @@ public class SpecificDateScheduleEntity extends ScheduleEntity {
   @JsonProperty("start_date_time")
   private LocalDateTime startDateTime;
 
-  @ApiModelProperty(example = DateHelper.DATE_TIME_FORMAT, required = true, position = 2)
+  @Schema(example = DateHelper.DATE_TIME_FORMAT, required = true)
   @JsonFormat(pattern = DateHelper.DATE_TIME_FORMAT)
   @JsonDeserialize(using = DateTimeDeserializer.class)
   @JsonSerialize(using = DateTimeSerializer.class)

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/ControllerExceptionHandler.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/ControllerExceptionHandler.java
@@ -28,14 +28,14 @@ public class ControllerExceptionHandler {
   public ResponseEntity<List<String>> handleException(HttpServletRequest req, Exception e) {
     logger.error("Internal Server Error", e);
 
-    return new ResponseEntity<>(null, null, HttpStatus.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<List<String>> handleMethodArgumentNotValidException(
       HttpServletRequest req, Exception e) {
 
-    return new ResponseEntity<>(null, null, HttpStatus.BAD_REQUEST);
+    return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(InvalidDataException.class)
@@ -43,7 +43,7 @@ public class ControllerExceptionHandler {
       HttpServletRequest req, Exception e) {
 
     List<String> errors = validationErrorResult.getAllErrorMessages();
-    return new ResponseEntity<>(errors, null, HttpStatus.BAD_REQUEST);
+    return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(SchedulerInternalException.class)
@@ -52,7 +52,7 @@ public class ControllerExceptionHandler {
     logger.error("Internal Server Error", e);
 
     List<String> errors = validationErrorResult.getAllErrorMessages();
-    return new ResponseEntity<>(errors, null, HttpStatus.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(errors, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   @ExceptionHandler(MissingServletRequestParameterException.class)
@@ -61,11 +61,11 @@ public class ControllerExceptionHandler {
 
   @ExceptionHandler(value = {ConstraintViolationException.class})
   protected ResponseEntity<Object> handleConstraintViolation(ConstraintViolationException e) {
-    return new ResponseEntity<>(e.getMessage(), null, HttpStatus.BAD_REQUEST);
+    return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(value = {NoResourceFoundException.class})
   protected ResponseEntity<Object> handleNoResourceFoundException(NoResourceFoundException e) {
-    return new ResponseEntity<>(e.getMessage(), null, e.getStatusCode());
+    return new ResponseEntity<>(e.getMessage(), e.getStatusCode());
   }
 }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestController.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestController.java
@@ -1,9 +1,11 @@
 package org.cloudfoundry.autoscaler.scheduler.rest;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -37,19 +39,24 @@ public class ScheduleRestController {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   @GetMapping
-  @ApiOperation(
-      value = "Get all schedules (specific dates and recurring) for the specified application id.",
-      produces = "application/json")
+  @Operation(
+      summary =
+          "Get all schedules (specific dates and recurring) for the specified application id.")
   @ApiResponses(
       value = {
         @ApiResponse(
-            code = 200,
-            message = "Schedules found for the specified application id.",
-            response = ApplicationSchedules.class),
-        @ApiResponse(code = 404, message = "No schedules found for the specified application id.")
+            responseCode = "200",
+            description = "Schedules found for the specified application id.",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApplicationSchedules.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "No schedules found for the specified application id.")
       })
   public ResponseEntity<ApplicationSchedules> getAllSchedules(
-      @ApiParam(name = "app_id", value = "The application id", required = true)
+      @Parameter(name = "app_id", description = "The application id", required = true)
           @PathVariable("app_id")
           @NotNull
           @UUID
@@ -60,29 +67,31 @@ public class ScheduleRestController {
 
     // No schedules found for the specified application return status code NOT_FOUND
     if (!savedApplicationSchedules.getSchedules().hasSchedules()) {
-      return new ResponseEntity<>(null, null, HttpStatus.NOT_FOUND);
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     } else {
-      return new ResponseEntity<>(savedApplicationSchedules, null, HttpStatus.OK);
+      return new ResponseEntity<>(savedApplicationSchedules, HttpStatus.OK);
     }
   }
 
   @PutMapping
   @ResponseStatus(HttpStatus.OK)
-  @ApiOperation(
-      value = "Create/Modify schedules for the specified application id.",
-      consumes = "application/json")
+  @Operation(summary = "Create/Modify schedules for the specified application id.")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "Schedules created for the specified application id."),
-        @ApiResponse(code = 204, message = "Schedules modified for the specified application id.")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Schedules created for the specified application id."),
+        @ApiResponse(
+            responseCode = "204",
+            description = "Schedules modified for the specified application id.")
       })
   public ResponseEntity<List<String>> createSchedules(
-      @ApiParam(name = "app_id", value = "The application id", required = true)
+      @Parameter(name = "app_id", description = "The application id", required = true)
           @PathVariable("app_id")
           @NotNull
           @UUID
           String appId,
-      @ApiParam(name = "guid", value = "The policy guid", required = true)
+      @Parameter(name = "guid", description = "The policy guid", required = true)
           @RequestParam("guid")
           @NotNull
           @UUID
@@ -108,28 +117,28 @@ public class ScheduleRestController {
     }
 
     if (isUpdateScheduleRequest) {
-      return new ResponseEntity<>(null, null, HttpStatus.NO_CONTENT);
+      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    return new ResponseEntity<>(null, null, HttpStatus.OK);
+    return new ResponseEntity<>(HttpStatus.OK);
   }
 
   @DeleteMapping
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @ApiOperation(
-      value =
+  @Operation(
+      summary =
           "Delete all schedules (specific dates and recurring) for the specified application id.")
   @ApiResponses(
       value = {
         @ApiResponse(
-            code = 204,
-            message = "All schedules deleted for the specified application id."),
+            responseCode = "204",
+            description = "All schedules deleted for the specified application id."),
         @ApiResponse(
-            code = 404,
-            message = "No schedules found for deletion for the specified application id.")
+            responseCode = "404",
+            description = "No schedules found for deletion for the specified application id.")
       })
   public ResponseEntity<List<String>> deleteSchedules(
-      @ApiParam(name = "app_id", value = "The application id", required = true)
+      @Parameter(name = "app_id", description = "The application id", required = true)
           @PathVariable("app_id")
           @NotNull
           @UUID
@@ -137,12 +146,12 @@ public class ScheduleRestController {
 
     Schedules existingSchedules = scheduleManager.getAllSchedules(appId).getSchedules();
     if (!existingSchedules.hasSchedules()) {
-      return new ResponseEntity<>(null, null, HttpStatus.NOT_FOUND);
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
     logger.info("Delete schedules for application: {}", appId);
     scheduleManager.deleteSchedules(appId);
 
-    return new ResponseEntity<>(null, null, HttpStatus.NO_CONTENT);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestController.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestController.java
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,11 +19,11 @@ public class ScheduleSyncRestController {
   @Autowired private ScheduleManager scheduleManager;
   private Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  @RequestMapping(method = RequestMethod.PUT)
+  @PutMapping
   @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<SynchronizeResult> synchronizeSchedules() {
     logger.info("synchronize schedules");
     SynchronizeResult result = scheduleManager.synchronizeSchedules();
-    return new ResponseEntity<>(result, null, HttpStatus.OK);
+    return new ResponseEntity<>(result, HttpStatus.OK);
   }
 }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/model/ApplicationSchedules.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/model/ApplicationSchedules.java
@@ -1,27 +1,26 @@
 package org.cloudfoundry.autoscaler.scheduler.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 /** */
-@ApiModel
+@Schema
 public class ApplicationSchedules {
-  @ApiModelProperty(required = true)
+  @Schema(required = true)
   @NotNull
   @Min(value = 1)
   @JsonProperty(value = "instance_min_count")
   Integer instanceMinCount;
 
-  @ApiModelProperty(required = true)
+  @Schema(required = true)
   @NotNull
   @Min(value = 1)
   @JsonProperty(value = "instance_max_count")
   Integer instanceMaxCount;
 
-  @ApiModelProperty(required = true)
+  @Schema(required = true)
   @NotNull
   Schedules schedules;
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/model/Schedules.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/rest/model/Schedules.java
@@ -1,25 +1,24 @@
 package org.cloudfoundry.autoscaler.scheduler.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.cloudfoundry.autoscaler.scheduler.entity.RecurringScheduleEntity;
 import org.cloudfoundry.autoscaler.scheduler.entity.SpecificDateScheduleEntity;
 
-@ApiModel
+@Schema
 public class Schedules {
-  @ApiModelProperty(required = true, position = 1)
+  @Schema(required = true)
   @JsonProperty(value = "timezone")
   @NotBlank
   String timeZone;
 
-  @ApiModelProperty(position = 3)
+  @Schema
   @JsonProperty(value = "specific_date")
   private List<SpecificDateScheduleEntity> specificDate;
 
-  @ApiModelProperty(position = 2)
+  @Schema
   @JsonProperty(value = "recurring_schedule")
   private List<RecurringScheduleEntity> recurringSchedule;
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManager.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManager.java
@@ -1,8 +1,5 @@
 package org.cloudfoundry.autoscaler.scheduler.service;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,6 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestOperations;
+import tools.jackson.databind.ObjectMapper;
 
 /** Service class to persist the schedule entity in the database and create scheduled job. */
 @Service
@@ -446,39 +444,33 @@ public class ScheduleManager {
     ObjectMapper mapper = new ObjectMapper();
     String policyJson = policyJsonEntity.getPolicyJson();
     ApplicationSchedules applicationSchedules = null;
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    try {
-      applicationSchedules = mapper.readValue(policyJson, ApplicationSchedules.class);
-      if (applicationSchedules != null
-          && applicationSchedules.getSchedules() != null
-          && applicationSchedules.getSchedules().hasSchedules()) {
-        Schedules schedules = applicationSchedules.getSchedules();
-        List<RecurringScheduleEntity> recurringSchedules = schedules.getRecurringSchedule();
-        List<SpecificDateScheduleEntity> specificDateSchedules = schedules.getSpecificDate();
-        if (recurringSchedules != null) {
-          for (RecurringScheduleEntity recurring : recurringSchedules) {
-            recurring.setAppId(policyJsonEntity.getAppId());
-            recurring.setTimeZone(schedules.getTimeZone());
-            recurring.setDefaultInstanceMinCount(applicationSchedules.getInstanceMinCount());
-            recurring.setDefaultInstanceMaxCount(applicationSchedules.getInstanceMaxCount());
-            recurring.setGuid(policyJsonEntity.getGuid());
-          }
-        }
-        if (specificDateSchedules != null) {
-          for (SpecificDateScheduleEntity specificDate : specificDateSchedules) {
-            specificDate.setAppId(policyJsonEntity.getAppId());
-            specificDate.setTimeZone(schedules.getTimeZone());
-            specificDate.setDefaultInstanceMinCount(applicationSchedules.getInstanceMinCount());
-            specificDate.setDefaultInstanceMaxCount(applicationSchedules.getInstanceMaxCount());
-            specificDate.setGuid(policyJsonEntity.getGuid());
-          }
+    applicationSchedules = mapper.readValue(policyJson, ApplicationSchedules.class);
+    if (applicationSchedules != null
+        && applicationSchedules.getSchedules() != null
+        && applicationSchedules.getSchedules().hasSchedules()) {
+      Schedules schedules = applicationSchedules.getSchedules();
+      List<RecurringScheduleEntity> recurringSchedules = schedules.getRecurringSchedule();
+      List<SpecificDateScheduleEntity> specificDateSchedules = schedules.getSpecificDate();
+      if (recurringSchedules != null) {
+        for (RecurringScheduleEntity recurring : recurringSchedules) {
+          recurring.setAppId(policyJsonEntity.getAppId());
+          recurring.setTimeZone(schedules.getTimeZone());
+          recurring.setDefaultInstanceMinCount(applicationSchedules.getInstanceMinCount());
+          recurring.setDefaultInstanceMaxCount(applicationSchedules.getInstanceMaxCount());
+          recurring.setGuid(policyJsonEntity.getGuid());
         }
       }
-
-    } catch (IOException e) {
-      logger.error("Failed to parse policy, policy_json:" + policyJson, e);
-      applicationSchedules = null;
+      if (specificDateSchedules != null) {
+        for (SpecificDateScheduleEntity specificDate : specificDateSchedules) {
+          specificDate.setAppId(policyJsonEntity.getAppId());
+          specificDate.setTimeZone(schedules.getTimeZone());
+          specificDate.setDefaultInstanceMinCount(applicationSchedules.getInstanceMinCount());
+          specificDate.setDefaultInstanceMaxCount(applicationSchedules.getInstanceMaxCount());
+          specificDate.setGuid(policyJsonEntity.getGuid());
+        }
+      }
     }
+
     return applicationSchedules;
   }
 

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateDeserializer.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateDeserializer.java
@@ -1,16 +1,15 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class DateDeserializer extends JsonDeserializer<LocalDate> {
+public class DateDeserializer extends ValueDeserializer<LocalDate> {
 
   @Override
-  public LocalDate deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+  public LocalDate deserialize(JsonParser parser, DeserializationContext ctxt) {
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DateHelper.DATE_FORMAT);
     return LocalDate.parse(parser.getValueAsString(), dateTimeFormatter);
   }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateSerializer.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateSerializer.java
@@ -1,17 +1,15 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class DateSerializer extends JsonSerializer<LocalDate> {
+public class DateSerializer extends ValueSerializer<LocalDate> {
 
   @Override
-  public void serialize(LocalDate value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(LocalDate value, JsonGenerator gen, SerializationContext serializers) {
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DateHelper.DATE_FORMAT);
     gen.writeString(value.format(dateTimeFormatter));
   }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateTimeDeserializer.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateTimeDeserializer.java
@@ -1,17 +1,15 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class DateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+public class DateTimeDeserializer extends ValueDeserializer<LocalDateTime> {
 
   @Override
-  public LocalDateTime deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+  public LocalDateTime deserialize(JsonParser parser, DeserializationContext ctxt) {
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DateHelper.DATE_TIME_FORMAT);
     return LocalDateTime.parse(parser.getValueAsString(), dateTimeFormatter);
   }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateTimeSerializer.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/DateTimeSerializer.java
@@ -1,17 +1,15 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class DateTimeSerializer extends JsonSerializer<LocalDateTime> {
+public class DateTimeSerializer extends ValueSerializer<LocalDateTime> {
 
   @Override
-  public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(LocalDateTime value, JsonGenerator gen, SerializationContext serializers) {
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DateHelper.DATE_TIME_FORMAT);
     gen.writeString(value.format(dateTimeFormatter));
   }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/ScheduleJobHelper.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/ScheduleJobHelper.java
@@ -114,7 +114,7 @@ public class ScheduleJobHelper {
     String dayOfWeek = convertArrayToDayOfWeekString(recurringScheduleEntity.getDaysOfWeek());
     String dayOfMonth = convertArrayToDayOfMonthString(recurringScheduleEntity.getDaysOfMonth());
 
-    return String.format("00 %02d %02d %s * %s *", min, hour, dayOfMonth, dayOfWeek);
+    return "00 %02d %02d %s * %s *".formatted(min, hour, dayOfMonth, dayOfWeek);
   }
 
   private static String convertArrayToDayOfWeekString(int[] dayOfWeek) {

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/TimeDeserializer.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/TimeDeserializer.java
@@ -1,17 +1,15 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class TimeDeserializer extends JsonDeserializer<LocalTime> {
+public class TimeDeserializer extends ValueDeserializer<LocalTime> {
 
   @Override
-  public LocalTime deserialize(final JsonParser jp, final DeserializationContext ctxt)
-      throws IOException {
+  public LocalTime deserialize(final JsonParser jp, final DeserializationContext ctxt) {
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DateHelper.TIME_FORMAT);
     return LocalTime.parse(jp.getValueAsString(), dateTimeFormatter);
   }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/TimeSerializer.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/TimeSerializer.java
@@ -1,17 +1,15 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class TimeSerializer extends JsonSerializer<LocalTime> {
+public class TimeSerializer extends ValueSerializer<LocalTime> {
 
   @Override
-  public void serialize(LocalTime value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(LocalTime value, JsonGenerator gen, SerializationContext serializers) {
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DateHelper.TIME_FORMAT);
     gen.writeString(value.format(dateTimeFormatter));
   }

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/DataSourceConfigurationException.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/DataSourceConfigurationException.java
@@ -1,10 +1,11 @@
 package org.cloudfoundry.autoscaler.scheduler.util.error;
 
+import java.io.Serial;
 import org.springframework.beans.factory.BeanCreationException;
 
 public class DataSourceConfigurationException extends BeanCreationException {
   /** */
-  private static final long serialVersionUID = 6522875947154155552L;
+  @Serial private static final long serialVersionUID = 6522875947154155552L;
 
   public DataSourceConfigurationException(String dataSourceName, String msg, Throwable t) {
     super(dataSourceName, msg, t);

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/DatabaseValidationException.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/DatabaseValidationException.java
@@ -1,8 +1,10 @@
 package org.cloudfoundry.autoscaler.scheduler.util.error;
 
+import java.io.Serial;
+
 public class DatabaseValidationException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   public DatabaseValidationException() {
     super();

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/InternalCodingError.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/InternalCodingError.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.autoscaler.scheduler.util.error;
 
+import java.io.Serial;
+
 /**
  * An exception thrown when coding errors that can't be avoided by design occur at runtime.
  *
@@ -11,7 +13,7 @@ package org.cloudfoundry.autoscaler.scheduler.util.error;
  */
 public class InternalCodingError extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   /**
    * @param message - the message indicating the application coding problem that has occurred

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/InvalidDataException.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/InvalidDataException.java
@@ -1,8 +1,10 @@
 package org.cloudfoundry.autoscaler.scheduler.util.error;
 
+import java.io.Serial;
+
 public class InvalidDataException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   public InvalidDataException() {
     super();

--- a/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/SchedulerInternalException.java
+++ b/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/util/error/SchedulerInternalException.java
@@ -1,8 +1,10 @@
 package org.cloudfoundry.autoscaler.scheduler.util.error;
 
+import java.io.Serial;
+
 public class SchedulerInternalException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   public SchedulerInternalException() {
     super();

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfigTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfigTest.java
@@ -4,15 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = DataSourceProperties.class)
 @SpringBootTest
 public class DataSourceConfigTest {

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/health/SchedulerHealthDefaultEndpointTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/health/SchedulerHealthDefaultEndpointTest.java
@@ -5,13 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.prometheus.client.exporter.HTTPServer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
+@AutoConfigureTestRestTemplate
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 public class SchedulerHealthDefaultEndpointTest {

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/health/SchedulerHealthEndpointTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/health/SchedulerHealthEndpointTest.java
@@ -6,14 +6,16 @@ import io.prometheus.client.exporter.HTTPServer;
 import org.cloudfoundry.autoscaler.scheduler.conf.CfHttpConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
+@AutoConfigureTestRestTemplate
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @ActiveProfiles("HealthAuth")

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/misc/ConcurrentRequestTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/misc/ConcurrentRequestTest.java
@@ -3,7 +3,6 @@ package org.cloudfoundry.autoscaler.scheduler.misc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -18,32 +17,34 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.web.client.RestOperations;
+import org.springframework.test.web.servlet.client.RestTestClient;
 
+@AutoConfigureRestTestClient
 @SpringBootTest
-public class ConcurrentRequestTest {
+class ConcurrentRequestTest {
 
   @Value("${autoscaler.scalingengine.url}")
   private String scalingEngineUrl;
 
-  @Autowired private RestOperations restOperations;
+  @Autowired private RestTestClient restTestClient;
 
   private static EmbeddedTomcatUtil embeddedTomcatUtil;
 
   @BeforeAll
-  public static void beforeClass() throws IOException {
+  static void beforeClass() {
     embeddedTomcatUtil = new EmbeddedTomcatUtil();
     embeddedTomcatUtil.start();
   }
 
   @AfterAll
-  public static void afterClass() throws IOException, InterruptedException {
+  static void afterClass() {
     embeddedTomcatUtil.stop();
   }
 
   @Test
-  public void testMultipleRequests() throws Exception {
+  void testMultipleRequests() throws Exception {
 
     String appId = "appId";
     long scheduleId = 0L;
@@ -62,7 +63,12 @@ public class ConcurrentRequestTest {
     Callable<Throwable> task =
         () -> {
           try {
-            restOperations.delete(scalingEnginePathActiveSchedule);
+            restTestClient
+                .delete()
+                .uri(scalingEnginePathActiveSchedule)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
             return null;
           } catch (Throwable th) {
             return th;

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerCreateScheduleAndNotifyScalingEngineTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerCreateScheduleAndNotifyScalingEngineTest.java
@@ -7,8 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,11 +44,12 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @Commit
-public class ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest {
+class ScheduleRestControllerCreateScheduleAndNotifyScalingEngineTest {
 
   @Autowired private MessageBundleResourceHelper messageBundleResourceHelper;
 
@@ -67,13 +66,13 @@ public class ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest {
   private static EmbeddedTomcatUtil embeddedTomcatUtil;
 
   @BeforeAll
-  public static void beforeClass() throws IOException {
+  static void beforeClass() {
     embeddedTomcatUtil = new EmbeddedTomcatUtil();
     embeddedTomcatUtil.start();
   }
 
   @AfterAll
-  public static void afterClass() throws IOException, InterruptedException {
+  static void afterClass() {
     embeddedTomcatUtil.stop();
   }
 
@@ -86,7 +85,7 @@ public class ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest {
 
   @BeforeEach
   @Transactional
-  public void before() throws Exception {
+  void before() throws Exception {
     // Clean up data
     testDataDbUtil.cleanupData(scheduler);
 
@@ -99,7 +98,7 @@ public class ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest {
   }
 
   @Test
-  public void testCreateScheduleAndNotifyScalingEngine() throws Exception {
+  void testCreateScheduleAndNotifyScalingEngine() throws Exception {
     createSchedule();
 
     // Assert START Job successful message
@@ -117,7 +116,7 @@ public class ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest {
   }
 
   @Test
-  public void testDeleteSchedule() throws Exception {
+  void testDeleteSchedule() throws Exception {
     createSchedule();
 
     // Assert START Job successful message
@@ -138,7 +137,7 @@ public class ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest {
   }
 
   @Test
-  public void testQuartzSetting() throws SchedulerException {
+  void testQuartzSetting() throws SchedulerException {
     assertThat(scheduler.getSchedulerName(), is("app-autoscaler"));
     assertThat(scheduler.getSchedulerInstanceId(), is("scheduler-12345"));
   }

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerTest.java
@@ -13,10 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.text.DateFormat;
 import java.util.List;
 import org.cloudfoundry.autoscaler.scheduler.dao.ActiveScheduleDao;
 import org.cloudfoundry.autoscaler.scheduler.dao.SpecificDateScheduleDao;
@@ -46,6 +43,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
@@ -374,7 +373,7 @@ public class ScheduleRestControllerTest {
     resultActions.andExpect(status().isBadRequest());
   }
 
-  private static String getPolicyString() throws JsonProcessingException {
+  private static String getPolicyString() throws JacksonException {
     ObjectMapper mapper = new ObjectMapper();
     ApplicationSchedules applicationPolicy = TestDataSetupHelper.generateApplicationPolicy(1, 0);
     String content = mapper.writeValueAsString(applicationPolicy);
@@ -613,7 +612,7 @@ public class ScheduleRestControllerTest {
   private ApplicationSchedules getApplicationSchedulesFromResultActions(ResultActions resultActions)
       throws IOException {
     ObjectMapper mapper = new ObjectMapper();
-    mapper.setDateFormat(DateFormat.getDateInstance(DateFormat.LONG));
+    // TODO mapper.setDateFormat(DateFormat.getDateInstance(DateFormat.LONG));
     return mapper.readValue(
         resultActions.andReturn().getResponse().getContentAsString(), ApplicationSchedules.class);
   }

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestControllerTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestControllerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cloudfoundry.autoscaler.scheduler.dao.ActiveScheduleDao;
 import org.cloudfoundry.autoscaler.scheduler.entity.ActiveScheduleEntity;
 import org.cloudfoundry.autoscaler.scheduler.rest.model.Schedules;
@@ -27,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManagerTest.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManagerTest.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withNoContent;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,6 +67,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
+import tools.jackson.core.JacksonException;
 
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest
@@ -804,7 +804,7 @@ public class ScheduleManagerTest {
 
   @Test
   public void testSynchronizeSchedules_with_existed_policy_and_no_schedule()
-      throws JsonProcessingException {
+      throws JacksonException {
 
     String appId = TestDataSetupHelper.generateAppIds(1)[0];
     String guid = TestDataSetupHelper.generateGuid();
@@ -916,7 +916,7 @@ public class ScheduleManagerTest {
   @Test
   public void
       testSynchronizeSchedules_with_both_policy_with_schedules_and_schedules_existed_and_guid_are_different()
-          throws JsonProcessingException {
+          throws JacksonException {
     String appId = TestDataSetupHelper.generateAppIds(1)[0];
     String guid = TestDataSetupHelper.generateGuid();
     String anotherGuid = TestDataSetupHelper.generateGuid();
@@ -1014,7 +1014,7 @@ public class ScheduleManagerTest {
 
   @Test
   public void testSynchronizeSchedules_with_both_policy_without_schedule_and_schedules_existed()
-      throws JsonProcessingException {
+      throws JacksonException {
     String appId = TestDataSetupHelper.generateAppIds(1)[0];
     String guid = TestDataSetupHelper.generateGuid();
     String anotherGuid = TestDataSetupHelper.generateGuid();
@@ -1078,7 +1078,7 @@ public class ScheduleManagerTest {
   @Test
   public void
       testSynchronizeSchedules_with_both_policy_and_schedules_existed_and_guid_are_the_same()
-          throws JsonProcessingException {
+          throws JacksonException {
     String appId = TestDataSetupHelper.generateAppIds(1)[0];
     String guid = TestDataSetupHelper.generateGuid();
     int noOfSpecificDateSchedules = 3;

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/PolicyJsonEntityBuilder.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/PolicyJsonEntityBuilder.java
@@ -1,16 +1,16 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cloudfoundry.autoscaler.scheduler.entity.PolicyJsonEntity;
 import org.cloudfoundry.autoscaler.scheduler.rest.model.ApplicationSchedules;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public class PolicyJsonEntityBuilder {
 
   private PolicyJsonEntity policyJson;
 
   public PolicyJsonEntityBuilder(String appId, String guid, ApplicationSchedules schedules)
-      throws JsonProcessingException {
+      throws JacksonException {
     this.policyJson = new PolicyJsonEntity();
     this.policyJson.setAppId(appId);
     this.policyJson.setGuid(guid);

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/TestDataDbUtil.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/TestDataDbUtil.java
@@ -13,11 +13,13 @@ import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.matchers.GroupMatcher;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
+@DependsOnDatabaseInitialization
 public class TestDataDbUtil {
 
   @Resource(name = "dataSource")

--- a/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/TestDataSetupHelper.java
+++ b/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/util/TestDataSetupHelper.java
@@ -1,7 +1,5 @@
 package org.cloudfoundry.autoscaler.scheduler.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -34,6 +32,8 @@ import org.quartz.Trigger;
 import org.quartz.TriggerKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /** Class to set up the test data for the test classes */
 public class TestDataSetupHelper {
@@ -143,7 +143,7 @@ public class TestDataSetupHelper {
 
   public static String generateJsonSchedule(
       int noOfSpecificDateSchedulesToSetUp, int noOfRecurringSchedulesToSetUp)
-      throws JsonProcessingException {
+      throws JacksonException {
     ObjectMapper mapper = new ObjectMapper();
 
     ApplicationSchedules applicationPolicy =
@@ -335,7 +335,7 @@ public class TestDataSetupHelper {
   }
 
   public static String getSchedulerPath(String appId) {
-    return String.format("/v1/apps/%s/schedules", appId);
+    return "/v1/apps/%s/schedules".formatted(appId);
   }
 
   static String getTimeZone() {


### PR DESCRIPTION
# Issue
The used version of [Spring Boot (3.5) goes out of maintenance in a week](https://endoflife.date/spring-boot).

# Fix
Bump Spring Boot to latest 4.1 and adapt codebase to the required change. Change was mainly done by Moderne OpenRewrite and Claude.