### PR TITLE
perf: parallelize cleanup of autoscaler deployments

### DIFF
--- a/scripts/cleanup-autoscaler-deployments.sh
+++ b/scripts/cleanup-autoscaler-deployments.sh
@@ -13,25 +13,35 @@ function get_autoscaler_deployments(){
 	cf curl /v3/organizations | jq -r '.resources[] | select(.name | contains("autoscaler")) | .name'
 }
 
+function cleanup_deployment(){
+	unset_vars
+	export DEPLOYMENT_NAME="$1"
+	# shellcheck source=scripts/vars.source.sh
+	source "${script_dir}/vars.source.sh"
+	step "[${DEPLOYMENT_NAME}] starting cleanup"
+	cleanup_acceptance_run
+	cleanup_service_broker
+	cleanup_credhub
+	cleanup_apps
+	step "[${DEPLOYMENT_NAME}] done"
+}
+
 function main(){
 	bbl_login
 	cf_login
-	local deployments
+	local deployments pids=() pid exit_code=0
 	deployments=$(get_autoscaler_deployments)
 	step "Deployments to cleanup: ${deployments}"
-	while IFS='' read -r deployment
-	do
-		unset_vars
-		export DEPLOYMENT_NAME="${deployment}"
-		# shellcheck source=scripts/vars.source.sh
-		source "${script_dir}/vars.source.sh"
 
-		cleanup_acceptance_run
-		cleanup_service_broker
-		cleanup_credhub
-	  cleanup_apps
+	while IFS='' read -r deployment; do
+		cleanup_deployment "${deployment}" &
+		pids+=($!)
 	done <<< "${deployments}"
 
+	for pid in "${pids[@]}"; do
+		wait "${pid}" || exit_code=$?
+	done
+	return "${exit_code}"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Cleanup loop ran serially: each deployment processed one at a time (~33 min total for today's run)
- Each deployment's cleanup steps (`cleanup_acceptance_run`, `cleanup_service_broker`, `cleanup_credhub`, `cleanup_apps`) are fully independent across deployments
- Extract per-deployment work into `cleanup_deployment()`, background it with `&`, collect all PIDs, then `wait` each — propagating any non-zero exit code

Wall-clock time now equals the slowest single deployment rather than sum of all deployments.

## Test plan

- [ ] Trigger `Cleanup Autoscaler Deployments` workflow via `workflow_dispatch` and verify deployments cleaned up correctly
- [ ] Confirm exit code is non-zero if any single deployment cleanup fails (error propagation via `wait` loop)