### PR TITLE
chore: disable renovate auto-updates for fly CLI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,16 @@
       "enabled": false
     },
     {
+      "description": "Disable fly version updates — must match deployed Concourse server version manually",
+      "matchManagers": [
+        "devbox"
+      ],
+      "matchDepNames": [
+        "fly"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Group Ginkgo CLI and library updates together",
       "groupName": "ginkgo",
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- Disables renovate from auto-updating the `fly` devbox package
- `fly` version must match the deployed Concourse server version — renovate bumping it independently causes CLI/server version mismatch

## Test plan
- [ ] Verify renovate no longer opens PRs to bump `fly` in `devbox.json`