### PR TITLE
fix(mta): make custom builders self-sufficient for standalone mbt build

### DIFF
--- a/.github/workflows/acceptance_tests_reusable.yaml
+++ b/.github/workflows/acceptance_tests_reusable.yaml
@@ -64,7 +64,7 @@ jobs:
           USE_METRICSGATEWAY: ${{ inputs.use_metricsgateway }}
         run: |
           make --directory="${AUTOSCALER_DIR}" build-extension-file
-          make --directory="${AUTOSCALER_DIR}" mta-build
+          "${AUTOSCALER_DIR}/scripts/mta-build.sh"
           make --directory="${AUTOSCALER_DIR}" mta-deploy
 
   acceptance_tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,6 @@ make build                    # Build all Go services
 make scheduler.build          # Build Java scheduler component
 make build-test-app          # Build test application
 make build_all               # Build everything (programs + tests)
-make mta-build               # Build MTA archive for Cloud Foundry deployment
 ```
 
 ### Testing

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,16 @@ DEST ?= /tmp/build
 TARGET_DIR ?= ./build
 MTAR_FILENAME ?= app-autoscaler-release-v$(VERSION).mtar
 ACCEPTANCE_TESTS_FILE ?= ${DEST}/app-autoscaler-acceptance-tests-v$(VERSION).tgz
-AUTOSCALER_PLUGIN_VERSION ?= $(shell cf plugins --checksum 2>/dev/null | awk '/^AutoScaler/ {print $$2}')
+# Resolve the AutoScaler CLI plugin version from its single source of truth,
+# nix/packages.nix (the same pin the devbox env builds from), so the acceptance
+# release can be built in any environment with just awk — no running `cf` or a
+# pre-installed plugin required. Override by exporting AUTOSCALER_PLUGIN_VERSION.
+AUTOSCALER_PLUGIN_VERSION ?= $(shell awk '\
+	/app-autoscaler-cli-plugin = buildGoModule/{b=1} \
+	b && /major *=/{gsub(/[^0-9]/,"");maj=$$0} \
+	b && /minor *=/{gsub(/[^0-9]/,"");min=$$0} \
+	b && /patch *=/{gsub(/[^0-9]/,"");pat=$$0;print maj"."min"."pat;exit}' \
+	$(MAKEFILE_DIR)/nix/packages.nix)
 CI ?= false
 
 DEBUG := false
@@ -309,7 +318,10 @@ mta-logs:
 # the other dependencies. Instead we should rely on the dependencies being complete and updated
 # as needed.
 .PHONY: mta-build
-mta-build: mta-build-clean go-mod-vendor-mta vendor-changelogs
+# go-mod-vendor-mta and vendor-changelogs are invoked per-module by the custom
+# builders in mta.tpl.yaml, so `mbt build` (via mta-build.sh) is self-sufficient
+# and we don't run them here as well.
+mta-build: mta-build-clean
 	@$(MAKEFILE_DIR)/scripts/mta-build.sh
 
 .PHONY: mta-build-clean
@@ -366,7 +378,7 @@ acceptance-release: clean-acceptance generate-openapi-generated-clients-and-serv
 
 
 .PHONY: mta-release
-mta-release: generate-fakes mta-build
+mta-release: mta-build
 	@echo " - building mtar release '${VERSION}' to dir: '${DEST}' "
 
 .PHONY: clean-acceptance

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,15 @@ DEST ?= /tmp/build
 TARGET_DIR ?= ./build
 MTAR_FILENAME ?= app-autoscaler-release-v$(VERSION).mtar
 ACCEPTANCE_TESTS_FILE ?= ${DEST}/app-autoscaler-acceptance-tests-v$(VERSION).tgz
+
 # Resolve the AutoScaler CLI plugin version from its single source of truth,
 # nix/packages.nix (the same pin the devbox env builds from), so the acceptance
 # release can be built in any environment with just awk — no running `cf` or a
 # pre-installed plugin required. Override by exporting AUTOSCALER_PLUGIN_VERSION.
+#
+# In the future we will replace it with something simpler:
+# AUTOSCALER_PLUGIN_VERSION ?= $(shell \
+#	nix eval --raw '$(MAKEFILE_DIR)#app-autoscaler-cli-plugin.version')
 AUTOSCALER_PLUGIN_VERSION ?= $(shell awk '\
 	/app-autoscaler-cli-plugin = buildGoModule/{b=1} \
 	b && /major *=/{gsub(/[^0-9]/,"");maj=$$0} \
@@ -321,8 +326,15 @@ mta-logs:
 # go-mod-vendor-mta and vendor-changelogs are invoked per-module by the custom
 # builders in mta.tpl.yaml, so `mbt build` (via mta-build.sh) is self-sufficient
 # and we don't run them here as well.
-mta-build: mta-build-clean
-	@$(MAKEFILE_DIR)/scripts/mta-build.sh
+mta-build:
+	@echo -e \
+		'🚸 Responsible for the build of mtars is not GNUmake but mbt.' "\n" \
+		'mbt calls make to prepare its stage.' "\n" \
+		'Calling mbt via this Makefile is not intended and discouraged to keep responsibilities separated.' "\n" \
+		'You can invoke mbt by executing:' "\n" \
+		"\t" 'cp mta.tpl.yaml mta.yaml' "\n" \
+		"\t" 'sed --in-place "s/MTA_VERSION/$${VERSION}/g" mta.yaml' "\n" \
+		"\t" 'mbt build --target="<target-folder>" --mtar="<target-file-name>"'
 
 .PHONY: mta-build-clean
 mta-build-clean:
@@ -375,11 +387,6 @@ acceptance-release: clean-acceptance generate-openapi-generated-clients-and-serv
 	@chmod +x build/acceptance/bin/app-autoscaler-plugin
 	# Create tarball
 	@tar --create --auto-compress --file="${ACCEPTANCE_TESTS_FILE}" -C build acceptance
-
-
-.PHONY: mta-release
-mta-release: mta-build
-	@echo " - building mtar release '${VERSION}' to dir: '${DEST}' "
 
 .PHONY: clean-acceptance
 clean-acceptance:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ OpenAPI specifications are available in the [`openapi/`](./openapi/) directory:
 | `OPTS=--fix make lint`                                                | Check code style and apply auto-fixes                                      |
 | `make fmt`                                                            | Format Go code                                                             |
 | `make clean`                                                          | Remove build artifacts and generated code                                  |
-| `make mta-build`                                                      | Build MTA archive for deployment                                           |
 | `make mta-deploy`                                                     | Deploy to Cloud Foundry using MTA                                          |
 
 

--- a/mta.tpl.yaml
+++ b/mta.tpl.yaml
@@ -15,7 +15,11 @@ parameters:
 modules:
   - name: dbtasks
     type: java
-    path: .
+    # Per-submodule path so `mbt sbom-gen` runs cyclonedx makeAggregateBom against
+    # dbtasks/pom.xml alone (not the root reactor). Sharing `path: .` with the
+    # scheduler module makes mbt aggregate the whole reactor twice and merge two
+    # identical BOMs, which fails CycloneDX uniqueItems validation.
+    path: dbtasks
     properties:
       JBP_LOG_LEVEL:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 21.+ } }'
@@ -27,8 +31,17 @@ modules:
     build-parameters:
       builder: custom
       commands: # 🚧 To-do: embed me in the calling makefile
-        - make dbtasks.clean package-dbtasks
-      build-result: dbtasks/target/db-1.0-SNAPSHOT.jar
+        # `path: dbtasks` runs commands from dbtasks/; the make targets pushd into
+        # dbtasks/ and expect the repo root, so invoke make from the parent dir.
+        # `vendor-changelogs` copies the per-component *.db.changelog.{yml,yaml}
+        # into dbtasks/src/main/resources so `package` bundles them into the jar
+        # (they are .gitignored there, never committed). Running it here keeps a
+        # bare `mbt build` self-sufficient (rather than relying on it being run as
+        # an mta-build make prerequisite). Without it the apply-*-changelog deploy
+        # tasks fail with "BOOT-INF/classes/api.db.changelog.yml does not exist".
+        - make -C .. vendor-changelogs
+        - make -C .. dbtasks.clean package-dbtasks
+      build-result: target/db-1.0-SNAPSHOT.jar
     requires:
       - name: database
     parameters:
@@ -75,7 +88,15 @@ modules:
     build-parameters:
       builder: custom
       commands:
-        - echo "ignoring scheduler and dbtasks" > /dev/null
+        # Go modules ship SOURCE; the CF Go buildpack compiles at staging. It
+        # needs (a) the generated ogen `apis/scalinghistory` package, which is
+        # .gitignored and produced by `generate-openapi-...`, and (b) a `vendor/`
+        # dir so staging compiles air-gapped (the buildpack auto-uses vendor and
+        # makes no network calls). `go-mod-vendor-mta` does both (generate +
+        # `go mod vendor`). Running it here keeps a bare `mbt build`
+        # self-sufficient. Without it, apiserver/scalingengine fail staging with
+        # "no required module provides package .../apis/scalinghistory".
+        - make go-mod-vendor-mta
       ignore: ["acceptance", "build", "scheduler", "dbtasks", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: apiserver-config
@@ -100,7 +121,9 @@ modules:
     build-parameters:
       builder: custom
       commands:
-        - echo "ignoring scheduler, dbtasks and scalingengine" > /dev/null
+        # See the apiserver module: ships generated code + vendor/ for the
+        # air-gapped CF Go buildpack compile.
+        - make go-mod-vendor-mta
       ignore: ["acceptance", "build", "scheduler", "dbtasks", "scalingengine", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: eventgenerator-config
@@ -124,7 +147,9 @@ modules:
     build-parameters:
       builder: custom
       commands:
-        - echo "ignoring scheduler and dbtasks" > /dev/null
+        # See the apiserver module: ships generated code + vendor/ for the
+        # air-gapped CF Go buildpack compile.
+        - make go-mod-vendor-mta
       ignore: ["build", "scheduler", "dbtasks", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: metricsforwarder-config
@@ -149,7 +174,9 @@ modules:
     build-parameters:
       builder: custom
       commands:
-        - echo "ignoring scheduler and dbtasks" > /dev/null
+        # See the apiserver module: ships generated code + vendor/ for the
+        # air-gapped CF Go buildpack compile.
+        - make go-mod-vendor-mta
       ignore: ["acceptance", "build", "scheduler", "dbtasks", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: metricsgateway-config
@@ -173,7 +200,9 @@ modules:
     build-parameters:
       builder: custom
       commands:
-        - echo "ignoring scheduler, dbtasks and eventgenerator" > /dev/null
+        # See the apiserver module: ships generated code + vendor/ for the
+        # air-gapped CF Go buildpack compile.
+        - make go-mod-vendor-mta
       ignore: ["acceptance", "build", "scheduler", "dbtasks", "eventgenerator", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: operator-config
@@ -197,7 +226,9 @@ modules:
     build-parameters:
       builder: custom
       commands:
-        - echo "ignoring scheduler, dbtasks and eventgenerator" > /dev/null
+        # See the apiserver module: ships generated code + vendor/ for the
+        # air-gapped CF Go buildpack compile.
+        - make go-mod-vendor-mta
       ignore: ["acceptance", "build", "scheduler", "dbtasks", "eventgenerator", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: scalingengine-config
@@ -212,12 +243,16 @@ modules:
       routes:
   - name: scheduler
     type: java
-    path: .
+    # Per-submodule path so SBOM generation aggregates scheduler/pom.xml alone.
+    # See the dbtasks module for why sharing `path: .` breaks SBOM validation.
+    path: scheduler
     build-parameters:
       builder: custom
       commands: # 🚧 To-do: embed me in the calling makefile
-        - make scheduler.clean build-scheduler
-      build-result: scheduler/target/scheduler-1.0-SNAPSHOT.war
+        # `path: scheduler` runs commands from scheduler/; the make targets pushd
+        # into scheduler/ and expect the repo root, so invoke make from the parent.
+        - make -C .. scheduler.clean build-scheduler
+      build-result: target/scheduler-1.0-SNAPSHOT.war
     properties:
       JBP_LOG_LEVEL:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 21.+ } }'

--- a/mta.tpl.yaml
+++ b/mta.tpl.yaml
@@ -39,8 +39,8 @@ modules:
         # bare `mbt build` self-sufficient (rather than relying on it being run as
         # an mta-build make prerequisite). Without it the apply-*-changelog deploy
         # tasks fail with "BOOT-INF/classes/api.db.changelog.yml does not exist".
-        - make -C .. vendor-changelogs
-        - make -C .. dbtasks.clean package-dbtasks
+        - make --directory='..' vendor-changelogs
+        - make --directory='..' dbtasks.clean package-dbtasks
       build-result: target/db-1.0-SNAPSHOT.jar
     requires:
       - name: database
@@ -251,7 +251,7 @@ modules:
       commands: # 🚧 To-do: embed me in the calling makefile
         # `path: scheduler` runs commands from scheduler/; the make targets pushd
         # into scheduler/ and expect the repo root, so invoke make from the parent.
-        - make -C .. scheduler.clean build-scheduler
+        - make --directory='..' scheduler.clean build-scheduler
       build-result: target/scheduler-1.0-SNAPSHOT.war
     properties:
       JBP_LOG_LEVEL:

--- a/scripts/compile-acceptance-tests.sh
+++ b/scripts/compile-acceptance-tests.sh
@@ -20,15 +20,14 @@ GINKGO_TMPDIR=""
 cleanup() { [[ -n "${GINKGO_TMPDIR}" ]] && rm -rf "${GINKGO_TMPDIR}"; }
 trap cleanup EXIT
 
-# Build a host-native ginkgo tool from the version pinned in acceptance/go.mod
-# into the given path. Using `go build` (rather than a pre-installed `ginkgo` on
-# PATH) lets this run in any build image that has the go toolchain — e.g. the mbt
-# CI image — without ginkgo installed separately. The tool must be built for the
-# HOST platform (no GOOS/GOARCH override) so it can execute here; it cross-compiles
-# each suite for the target platform via the GOOS/GOARCH env passed to it.
-build_host_ginkgo() {
-  local out="${1}"
-  go build -C acceptance -o "${out}" github.com/onsi/ginkgo/v2/ginkgo
+# Build the ginkgo tool from the version pinned in acceptance/go.mod into the
+# given path. Using `go build` (rather than a pre-installed `ginkgo` on PATH)
+# lets this run in any build image that has the go toolchain — e.g. the mbt CI
+# image — without ginkgo installed separately. Pass GOOS/GOARCH to cross-compile
+# for a target platform, or leave both empty to build for the host platform.
+build_ginkgo() {
+  local out="${1}" goos="${2:-}" goarch="${3:-}"
+  CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build -C acceptance -o "${out}" github.com/onsi/ginkgo/v2/ginkgo
 }
 
 compile_suites() {
@@ -51,7 +50,7 @@ compile_ginkgo() {
     for arch in "${ARCHITECTURES[@]}"; do
       binary_name="ginkgo_v2_${os}_${arch}"
       output_path="build/acceptance/${binary_name}"
-      CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" go build -C acceptance -o "../${output_path}" github.com/onsi/ginkgo/v2/ginkgo
+      build_ginkgo "../${output_path}" "${os}" "${arch}"
       chmod +x "${output_path}"
     done
   done
@@ -63,7 +62,7 @@ main() {
   local ginkgo_bin
   GINKGO_TMPDIR="$(mktemp -d)"
   ginkgo_bin="${GINKGO_TMPDIR}/ginkgo"
-  build_host_ginkgo "${ginkgo_bin}"
+  build_ginkgo "${ginkgo_bin}"
 
   compile_suites "${ginkgo_bin}"
   compile_ginkgo

--- a/scripts/compile-acceptance-tests.sh
+++ b/scripts/compile-acceptance-tests.sh
@@ -13,12 +13,31 @@ read -ra SUITES <<< "$SUITES"
 read -ra OPERATING_SYSTEMS <<< "$OPERATING_SYSTEMS"
 read -ra ARCHITECTURES <<< "$ARCHITECTURES"
 
+# Temp dir for the host-native ginkgo tool; cleaned up on exit. Declared at the
+# top level (not inside a function) so the EXIT trap can reference it safely even
+# under `set -u`, since the trap fires after main() returns and its locals are gone.
+GINKGO_TMPDIR=""
+cleanup() { [[ -n "${GINKGO_TMPDIR}" ]] && rm -rf "${GINKGO_TMPDIR}"; }
+trap cleanup EXIT
+
+# Build a host-native ginkgo tool from the version pinned in acceptance/go.mod
+# into the given path. Using `go build` (rather than a pre-installed `ginkgo` on
+# PATH) lets this run in any build image that has the go toolchain — e.g. the mbt
+# CI image — without ginkgo installed separately. The tool must be built for the
+# HOST platform (no GOOS/GOARCH override) so it can execute here; it cross-compiles
+# each suite for the target platform via the GOOS/GOARCH env passed to it.
+build_host_ginkgo() {
+  local out="${1}"
+  go build -C acceptance -o "${out}" github.com/onsi/ginkgo/v2/ginkgo
+}
+
 compile_suites() {
+  local ginkgo_bin="${1}"
   for suite in "${SUITES[@]}"; do
       mkdir -p "build/acceptance/${suite}"
       for os in "${OPERATING_SYSTEMS[@]}"; do
         for arch in "${ARCHITECTURES[@]}"; do
-          CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" ginkgo build "acceptance/${suite}"
+          ( cd acceptance && CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" "${ginkgo_bin}" build "${suite}" )
 
           # adjust binary name to include os and architecture information
           mv "acceptance/${suite}/${suite}.test" "build/acceptance/${suite}/${suite}_${os}_${arch}.test"
@@ -39,7 +58,14 @@ compile_ginkgo() {
 }
 
 main() {
-  compile_suites
+  # Build the ginkgo tool once for the host platform into a temp dir, then use it
+  # to cross-compile the suites. Absolute path so it works after `cd acceptance`.
+  local ginkgo_bin
+  GINKGO_TMPDIR="$(mktemp -d)"
+  ginkgo_bin="${GINKGO_TMPDIR}/ginkgo"
+  build_host_ginkgo "${ginkgo_bin}"
+
+  compile_suites "${ginkgo_bin}"
   compile_ginkgo
   cp "acceptance/cleanup.sh" "build/acceptance/cleanup.sh"
 

--- a/scripts/compile-acceptance-tests.sh
+++ b/scripts/compile-acceptance-tests.sh
@@ -26,53 +26,53 @@ trap cleanup EXIT
 # image — without ginkgo installed separately. Pass GOOS/GOARCH to cross-compile
 # for a target platform, or leave both empty to build for the host platform.
 build_ginkgo() {
-  local out="${1}" goos="${2:-}" goarch="${3:-}"
-  CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build -C acceptance -o "${out}" github.com/onsi/ginkgo/v2/ginkgo
+	local out="${1}" goos="${2:-}" goarch="${3:-}"
+	CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build -C acceptance -o "${out}" github.com/onsi/ginkgo/v2/ginkgo
 }
 
 compile_suites() {
-  local ginkgo_bin="${1}"
-  for suite in "${SUITES[@]}"; do
-      mkdir -p "build/acceptance/${suite}"
-      for os in "${OPERATING_SYSTEMS[@]}"; do
-        for arch in "${ARCHITECTURES[@]}"; do
-          ( cd acceptance && CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" "${ginkgo_bin}" build "${suite}" )
+	local ginkgo_bin="${1}"
+	for suite in "${SUITES[@]}"; do
+			mkdir -p "build/acceptance/${suite}"
+			for os in "${OPERATING_SYSTEMS[@]}"; do
+				for arch in "${ARCHITECTURES[@]}"; do
+					( cd acceptance && CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" "${ginkgo_bin}" build "${suite}" )
 
-          # adjust binary name to include os and architecture information
-          mv "acceptance/${suite}/${suite}.test" "build/acceptance/${suite}/${suite}_${os}_${arch}.test"
-        done
-      done
-  done
+					# adjust binary name to include os and architecture information
+					mv "acceptance/${suite}/${suite}.test" "build/acceptance/${suite}/${suite}_${os}_${arch}.test"
+				done
+			done
+	done
 }
 
 compile_ginkgo() {
-  for os in "${OPERATING_SYSTEMS[@]}"; do
-    for arch in "${ARCHITECTURES[@]}"; do
-      binary_name="ginkgo_v2_${os}_${arch}"
-      output_path="build/acceptance/${binary_name}"
-      build_ginkgo "../${output_path}" "${os}" "${arch}"
-      chmod +x "${output_path}"
-    done
-  done
+	for os in "${OPERATING_SYSTEMS[@]}"; do
+		for arch in "${ARCHITECTURES[@]}"; do
+			binary_name="ginkgo_v2_${os}_${arch}"
+			output_path="build/acceptance/${binary_name}"
+			build_ginkgo "../${output_path}" "${os}" "${arch}"
+			chmod +x "${output_path}"
+		done
+	done
 }
 
 main() {
-  # Build the ginkgo tool once for the host platform into a temp dir, then use it
-  # to cross-compile the suites. Absolute path so it works after `cd acceptance`.
-  local ginkgo_bin
-  GINKGO_TMPDIR="$(mktemp -d)"
-  ginkgo_bin="${GINKGO_TMPDIR}/ginkgo"
-  build_ginkgo "${ginkgo_bin}"
+	# Build the ginkgo tool once for the host platform into a temp dir, then use it
+	# to cross-compile the suites. Absolute path so it works after `cd acceptance`.
+	local ginkgo_bin
+	GINKGO_TMPDIR="$(mktemp --directory)"
+	ginkgo_bin="${GINKGO_TMPDIR}/ginkgo"
+	build_ginkgo "${ginkgo_bin}"
 
-  compile_suites "${ginkgo_bin}"
-  compile_ginkgo
-  cp "acceptance/cleanup.sh" "build/acceptance/cleanup.sh"
+	compile_suites "${ginkgo_bin}"
+	compile_ginkgo
+	cp "acceptance/cleanup.sh" "build/acceptance/cleanup.sh"
 
-  # Copy test app assets
-  echo "Copying test app assets..."
-  mkdir -p "build/acceptance/assets/app/go_app/build"
-  cp -r "acceptance/assets/app/go_app/build/"* "build/acceptance/assets/app/go_app/build/"
-  cp -r "acceptance/assets/file/" "build/acceptance/assets/file/"
+	# Copy test app assets
+	echo "Copying test app assets..."
+	mkdir -p "build/acceptance/assets/app/go_app/build"
+	cp -r "acceptance/assets/app/go_app/build/"* "build/acceptance/assets/app/go_app/build/"
+	cp -r "acceptance/assets/file/" "build/acceptance/assets/file/"
 }
 
 main

--- a/scripts/create-assets.sh
+++ b/scripts/create-assets.sh
@@ -29,7 +29,7 @@ function create_mtar() {
 	local artifact_dir=$2
 	echo " - creating autoscaler mtar artifact"
 	pushd "${autoscaler_dir}" > /dev/null
-		make mta-release VERSION="${version}" DEST="${artifact_dir}"
+		VERSION="${version}" DEST="${artifact_dir}" ./scripts/mta-build.sh
 	popd > /dev/null
 }
 

--- a/scripts/mta-deploy.sh
+++ b/scripts/mta-deploy.sh
@@ -20,7 +20,7 @@ EXTENSION_FILE="${DEST}/extension-file-${VERSION}.txt"
 # Check if mtar file exists
 if [ ! -f "${DEST}/${MTAR_FILENAME}" ]; then
 	echo "ERROR: MTAR file not found at: ${DEST}/${MTAR_FILENAME}"
-	echo "Please run 'make mta-build' first"
+	echo "Please run 'scripts/mta-build.sh' first"
 	exit 1
 fi
 


### PR DESCRIPTION
# Issue

The MTA descriptor's custom builders relied on prerequisites that only run when mbt is invoked at the end of `make mta-build` (go-mod-vendor-mta, vendor-changelogs). Invoking mbt directly (e.g. from a CI that calls `mbt build` on its own) skips those, producing an MTAR that fails to deploy.

The acceptance-tests module builds via `make acceptance-release`, which assumed a devbox-provisioned environment. Two build-time assumptions prevented it from running in a minimal build image (e.g. the mbt CI image) that has the go toolchain but not ginkgo or the cf CLI.

# Fix

Fold those prerequisites into the builders themselves so `mbt build` is self-sufficient regardless of caller, and drop them from the mta-build / mta-release make targets (they now run per-module inside mbt).

Also give the Java modules (dbtasks, scheduler) their own submodule path so `mbt sbom-gen` aggregates each pom alone instead of the root reactor twice, which otherwise merges two identical BOMs and fails CycloneDX uniqueItems validation.

compile-acceptance-tests.sh invoked a pre-installed `ginkgo` on PATH: Build a host-native ginkgo from the version pinned in acceptance/go.mod instead, then use it to cross-compile each suite via GOOS/GOARCH. Needs only `go`.

AUTOSCALER_PLUGIN_VERSION was derived from `cf plugins --checksum`, requiring a running cf with the plugin installed: Resolve it from nix/packages.nix — the same single source of truth the devbox env builds the plugin from — using awk.

Both keep the existing devbox behavior unchanged while letting the acceptance release build in any environment with the go toolchain.