### PR TITLE
chore(CI): remove scale-to-one-az ops file to resolve smoke test failures on CF v58

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -259,7 +259,7 @@ jobs:
       vars-files: autoscaler-env-vars-store
     params:
       SYSTEM_DOMAIN: autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
-      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/autoscaler/add-eventgenerator-log-cache-uaa-client.yml operations/cf/experimental/disable-v2-api.yml operations/autoscaler/tag-vms-and-disks.yml operations/autoscaler/set-blobstore-disk.yml"
+      OPS_FILES: "operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/autoscaler/add-eventgenerator-log-cache-uaa-client.yml operations/cf/experimental/disable-v2-api.yml operations/autoscaler/tag-vms-and-disks.yml operations/autoscaler/set-blobstore-disk.yml"
       BOSH_DEPLOY_ARGS: "-v diego_cell_instances=3 -v grafana_redirect_uri=https://grafana.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org/login/generic_oauth"
     ensure:
       put: autoscaler-env-vars-store


### PR DESCRIPTION
## Problem

- Smoke tests consistently failed starting with CF v58.0.0
- Tests worked correctly on v57.4.0 and earlier
- Issue caused by breaking changes in CF v58 major version update


## Solution
Remove `operations/cf/scale-to-one-az.yml` from the OPS_FILES list in the CI pipeline configuration

## Testing
- Smoke tests pass on CF v58.0.0+
- Deployment pipeline completes successfully

<img width="2280" height="1249" alt="2026-07-22_17-09-53" src="https://github.com/user-attachments/assets/1c03ce0a-0f6e-4747-83cd-8c0320e5aa75" />

### Possible Follow up:  
Investigate if scaling down other VMS e.g nats, router etc can lead to successful cf deployment