### PR TITLE
fix(deploy): Missing UAA client "autosccaler_client_id" for  OAuth2 Authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ binaries=$(shell find . -name "main.go" -exec dirname {} \; |  cut -d/ -f2 | sor
 test_dirs=$(shell find . -name "*_test.go" -exec dirname {} \; |  cut -d/ -f2 | sort | uniq)
 export GO111MODULE=on
 
-.PHONY: dbtasks.clean package-dbtasks vendor-changelogs scheduler.clean package-scheduler clean mta-deploy mta-undeploy mta-build mta-logs
+.PHONY: dbtasks.clean package-dbtasks vendor-changelogs scheduler.clean package-scheduler clean mta-deploy mta-undeploy mta-build mta-logs create-uaa-client
 
 GINKGO_OPTS = -r --race --require-suite --randomize-all ${OPTS}
 
@@ -299,6 +299,9 @@ mta-undeploy:
 
 build-extension-file:
 	$(MAKEFILE_DIR)/scripts/build-extension-file.sh
+
+create-uaa-client:
+	$(MAKEFILE_DIR)/scripts/create-autoscaler-uaa-client.sh
 
 mta-logs:
 	rm -rf mta-*

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ binaries=$(shell find . -name "main.go" -exec dirname {} \; |  cut -d/ -f2 | sor
 test_dirs=$(shell find . -name "*_test.go" -exec dirname {} \; |  cut -d/ -f2 | sort | uniq)
 export GO111MODULE=on
 
-.PHONY: dbtasks.clean package-dbtasks vendor-changelogs scheduler.clean package-scheduler clean mta-deploy mta-undeploy mta-build mta-logs create-uaa-client
+.PHONY: dbtasks.clean package-dbtasks vendor-changelogs scheduler.clean package-scheduler clean mta-deploy mta-undeploy mta-build mta-logs
 
 GINKGO_OPTS = -r --race --require-suite --randomize-all ${OPTS}
 
@@ -299,9 +299,6 @@ mta-undeploy:
 
 build-extension-file:
 	$(MAKEFILE_DIR)/scripts/build-extension-file.sh
-
-create-uaa-client:
-	$(MAKEFILE_DIR)/scripts/create-autoscaler-uaa-client.sh
 
 mta-logs:
 	rm -rf mta-*

--- a/scripts/create-autoscaler-uaa-client.sh
+++ b/scripts/create-autoscaler-uaa-client.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+#
+# Creates the autoscaler_client_id UAA client that the autoscaler components
+# (API Server, Scaling Engine, Operator, Event Generator) use to authenticate
+# with Cloud Foundry API and UAA via OAuth2 client credentials flow.
+#
+# Required authorities:
+# - cloud_controller.read: Query application state and metadata
+# - cloud_controller.admin: Scale application instances up/down, sync schedules
+# - uaa.resource: Introspect user tokens via UAA /introspect endpoint (API server)
+# - routing.routes.{read,write}: Manage application routes
+# - routing.router_groups.read: Read router group information
+#
+# Usage:
+#   ./scripts/create-autoscaler-uaa-client.sh
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+# shellcheck source=scripts/vars.source.sh
+source "${script_dir}/vars.source.sh"
+# shellcheck source=scripts/common.sh
+source "${script_dir}/common.sh"
+
+# Configuration
+UAA_CLIENT_ID="autoscaler_client_id"
+UAA_CLIENT_SECRET="${AUTOSCALER_CLIENT_SECRET:-autoscaler_client_secret}"
+UAA_AUTHORITIES="cloud_controller.read,cloud_controller.admin,uaa.resource,routing.routes.write,routing.routes.read,routing.router_groups.read"
+GRANT_TYPES="client_credentials"
+
+echo "Creating UAA client for App Autoscaler..."
+echo "  Client ID: ${UAA_CLIENT_ID}"
+echo "  Authorities: ${UAA_AUTHORITIES}"
+echo "  Grant Types: ${GRANT_TYPES}"
+
+# Login to BOSH and get UAA admin credentials
+bbl_login
+
+# Get UAA admin client secret from credhub
+echo ""
+echo "Retrieving UAA admin client secret from credhub..."
+UAA_ADMIN_SECRET="$(credhub get -n /bosh-autoscaler/cf/uaa_admin_client_secret -q)"
+
+if [ -z "${UAA_ADMIN_SECRET}" ]; then
+  echo "ERROR: Failed to retrieve UAA admin secret from credhub"
+  exit 1
+fi
+
+# Target UAA
+echo ""
+echo "Targeting UAA at: https://uaa.${SYSTEM_DOMAIN}"
+uaa target "https://uaa.${SYSTEM_DOMAIN}" --skip-ssl-validation
+
+# Authenticate as admin
+echo ""
+echo "Authenticating as admin client..."
+uaa get-client-credentials-token admin -s "${UAA_ADMIN_SECRET}"
+
+# Check if client already exists
+echo ""
+if uaa get-client "${UAA_CLIENT_ID}" &> /dev/null; then
+  echo "Client '${UAA_CLIENT_ID}' already exists. Updating..."
+  uaa update-client "${UAA_CLIENT_ID}" \
+    --client_secret "${UAA_CLIENT_SECRET}" \
+    --authorized_grant_types "${GRANT_TYPES}" \
+    --authorities "${UAA_AUTHORITIES}"
+  echo "✓ Client '${UAA_CLIENT_ID}' updated successfully"
+else
+  echo "Creating new client '${UAA_CLIENT_ID}'..."
+  uaa create-client "${UAA_CLIENT_ID}" \
+    --client_secret "${UAA_CLIENT_SECRET}" \
+    --authorized_grant_types "${GRANT_TYPES}" \
+    --authorities "${UAA_AUTHORITIES}"
+  echo "✓ Client '${UAA_CLIENT_ID}' created successfully"
+fi
+
+# Verify the client was created/updated
+echo ""
+echo "Verifying client configuration..."
+uaa get-client "${UAA_CLIENT_ID}"
+
+echo ""
+echo "✓ UAA client setup complete!"
+echo ""
+echo "The Scaling Engine and Operator can now authenticate using:"
+echo "  Client ID: ${UAA_CLIENT_ID}"
+echo "  Client Secret: ${UAA_CLIENT_SECRET}"
+echo "  Grant Type: ${GRANT_TYPES}"
+echo "  Authorities: ${UAA_AUTHORITIES}"

--- a/scripts/create-autoscaler-uaa-client.sh
+++ b/scripts/create-autoscaler-uaa-client.sh
@@ -42,7 +42,7 @@ echo ""
 echo "Retrieving UAA admin client secret from credhub..."
 UAA_ADMIN_SECRET="$(credhub get -n /bosh-autoscaler/cf/uaa_admin_client_secret -q)"
 
-if [ -z "${UAA_ADMIN_SECRET}" ]; then
+if [[ -z "${UAA_ADMIN_SECRET}" ]]; then
   echo "ERROR: Failed to retrieve UAA admin secret from credhub"
   exit 1
 fi
@@ -62,7 +62,6 @@ echo ""
 if uaa get-client "${UAA_CLIENT_ID}" &> /dev/null; then
   echo "Client '${UAA_CLIENT_ID}' already exists. Updating..."
   uaa update-client "${UAA_CLIENT_ID}" \
-    --client_secret "${UAA_CLIENT_SECRET}" \
     --authorized_grant_types "${GRANT_TYPES}" \
     --authorities "${UAA_AUTHORITIES}"
   echo "✓ Client '${UAA_CLIENT_ID}' updated successfully"

--- a/scripts/create-autoscaler-uaa-client.sh
+++ b/scripts/create-autoscaler-uaa-client.sh
@@ -43,7 +43,7 @@ echo "Retrieving UAA admin client secret from credhub..."
 UAA_ADMIN_SECRET="$(credhub get -n /bosh-autoscaler/cf/uaa_admin_client_secret -q)"
 
 if [[ -z "${UAA_ADMIN_SECRET}" ]]; then
-  echo "ERROR: Failed to retrieve UAA admin secret from credhub"
+  echo "Failed to retrieve UAA admin secret from credhub"
   exit 1
 fi
 
@@ -64,14 +64,14 @@ if uaa get-client "${UAA_CLIENT_ID}" &> /dev/null; then
   uaa update-client "${UAA_CLIENT_ID}" \
     --authorized_grant_types "${GRANT_TYPES}" \
     --authorities "${UAA_AUTHORITIES}"
-  echo "✓ Client '${UAA_CLIENT_ID}' updated successfully"
+  echo "Client '${UAA_CLIENT_ID}' updated successfully"
 else
   echo "Creating new client '${UAA_CLIENT_ID}'..."
   uaa create-client "${UAA_CLIENT_ID}" \
     --client_secret "${UAA_CLIENT_SECRET}" \
     --authorized_grant_types "${GRANT_TYPES}" \
     --authorities "${UAA_AUTHORITIES}"
-  echo "✓ Client '${UAA_CLIENT_ID}' created successfully"
+  echo "Client '${UAA_CLIENT_ID}' created successfully"
 fi
 
 # Verify the client was created/updated
@@ -80,10 +80,4 @@ echo "Verifying client configuration..."
 uaa get-client "${UAA_CLIENT_ID}"
 
 echo ""
-echo "✓ UAA client setup complete!"
-echo ""
-echo "The Scaling Engine and Operator can now authenticate using:"
-echo "  Client ID: ${UAA_CLIENT_ID}"
-echo "  Client Secret: ${UAA_CLIENT_SECRET}"
-echo "  Grant Type: ${GRANT_TYPES}"
-echo "  Authorities: ${UAA_AUTHORITIES}"
+echo "UAA client setup complete!"

--- a/scripts/create-autoscaler-uaa-client.sh
+++ b/scripts/create-autoscaler-uaa-client.sh
@@ -9,8 +9,6 @@
 # - cloud_controller.read: Query application state and metadata
 # - cloud_controller.admin: Scale application instances up/down, sync schedules
 # - uaa.resource: Introspect user tokens via UAA /introspect endpoint (API server)
-# - routing.routes.{read,write}: Manage application routes
-# - routing.router_groups.read: Read router group information
 #
 # Usage:
 #   ./scripts/create-autoscaler-uaa-client.sh
@@ -26,7 +24,7 @@ source "${script_dir}/common.sh"
 # Configuration
 UAA_CLIENT_ID="autoscaler_client_id"
 UAA_CLIENT_SECRET="${AUTOSCALER_CLIENT_SECRET:-autoscaler_client_secret}"
-UAA_AUTHORITIES="cloud_controller.read,cloud_controller.admin,uaa.resource,routing.routes.write,routing.routes.read,routing.router_groups.read"
+UAA_AUTHORITIES="cloud_controller.read,cloud_controller.admin,uaa.resource"
 GRANT_TYPES="client_credentials"
 
 echo "Creating UAA client for App Autoscaler..."

--- a/scripts/mta-deploy.sh
+++ b/scripts/mta-deploy.sh
@@ -35,6 +35,13 @@ fi
 pushd "${autoscaler_dir}" > /dev/null
 
 	bbl_login
+
+	# Create UAA client for autoscaler (required for Scaling Engine and Operator)
+	echo ""
+	echo "=== Creating UAA Client for Autoscaler ==="
+	"${script_dir}/create-autoscaler-uaa-client.sh"
+	echo ""
+
 	make -f metricsforwarder/Makefile set-security-group
 	make -f metricsgateway/Makefile set-security-group
 	echo "Deploying with extension file: ${EXTENSION_FILE}"


### PR DESCRIPTION
## Problem

UAA client `autoscaler_client_id` is missing from deployment, causing OAuth2 authentication failures during the autoscaler deployment. This was likely missed during the migration from  app-autoscaler-release repo.
 
 Scaling Engine and Operator cannot authenticate with CF API without this UAA client.
 
 Error: oauth2: "invalid_client" "Bad credentials"
 
 ```
  ....
  2026-07-23T18:01:30.32+0200 [APP/PROC/WEB/0] OUT time=2026-07-23T16:01:30.323Z level=ERROR msg="scalingengine.failed to login cloud foundry" API=https://api.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org error="login failed: error executing GET request for /: error executing request, failed during HTTP request send: Get \"https://api.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org/\": oauth2: \"invalid_client\" \"Bad credentials\""
   2026-07-23T18:01:30.33+0200 [APP/PROC/WEB/0] OUT Exit status 1

 ```
 
 Affected GHA: 
https://github.com/cloudfoundry/app-autoscaler/actions/runs/29999163151
 
 ## Solution
 
 Automate UAA client creation/Update during deployment to prevent authentication failures (similar to [here](https://github.com/cloudfoundry/app-autoscaler-release/blob/bcc92a60c7fd2bf9755893151310579efd5bb14d/ci/autoscaler/scripts/deploy-autoscaler.sh#L34)).


Testing
https://github.com/cloudfoundry/app-autoscaler/actions/runs/30258769814/job/89953497588?pr=1326#step:7:870


