### PR TITLE
feat(sbom): generate Go dependency SBOM via mbt sbom-create-commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,17 @@ go-mod-vendor: generate-fakes
 go-mod-vendor-mta: generate-openapi-generated-clients-and-servers
 	GOFLAGS="-tags=!test" go mod vendor -e
 
+# Generate the Go dependency SBOM from the root go.mod. mbt's sbom-gen has no
+# built-in BOM logic for custom builders, so our Go services produce no SBOM on
+# their own. This target is wired into the apiserver module's
+# `sbom-create-commands` in mta.tpl.yaml, so mbt collects the output and merges
+# it into the aggregate SBOM. Emitted as CycloneDX 1.4 for best compatibility.
+# GO_SBOM_FILE is passed in by mbt via its ${sbom-file-name} placeholder.
+GO_SBOM_FILE ?= bom-go-mod.xml
+.PHONY: go-sbom
+go-sbom:
+	cyclonedx-gomod mod -output-version 1.4 -licenses -output "$(GO_SBOM_FILE)" .
+
 
 # CGO_ENABLED := 1 is required to enforce dynamic linking which is a requirement of dynatrace.
 build-%: generate-openapi-generated-clients-and-servers

--- a/devbox.json
+++ b/devbox.json
@@ -22,6 +22,8 @@
     "cloudfoundry-cli":     "8.18.3",
     "coreutils":            "9.11",
     "credhub-cli":          "2.9.54",
+    "cyclonedx-cli":        "0.32.0",
+    "cyclonedx-gomod":      "1.10.0",
     "curl":                 "8.17.0",
     "delve":                "1.26.3",
     "gh":                   "2.95.0",

--- a/devbox.lock
+++ b/devbox.lock
@@ -513,6 +513,92 @@
         }
       }
     },
+    "cyclonedx-cli@0.32.0": {
+      "last_modified": "2026-07-23T05:10:05Z",
+      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#cyclonedx-cli",
+      "source": "devbox-search",
+      "version": "0.32.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8fddy1afjjpk47imy8kxp3x0pkcr6bvx-cyclonedx-cli-0.32.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8fddy1afjjpk47imy8kxp3x0pkcr6bvx-cyclonedx-cli-0.32.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/41rhi7nd4jczax3rlic182rfxpfxzcmg-cyclonedx-cli-0.32.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/41rhi7nd4jczax3rlic182rfxpfxzcmg-cyclonedx-cli-0.32.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l25gpg1vbjqvgfsmzqlkydwmn3zh1axf-cyclonedx-cli-0.32.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/l25gpg1vbjqvgfsmzqlkydwmn3zh1axf-cyclonedx-cli-0.32.0"
+        }
+      }
+    },
+    "cyclonedx-gomod@1.10.0": {
+      "last_modified": "2026-07-23T05:10:05Z",
+      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#cyclonedx-gomod",
+      "source": "devbox-search",
+      "version": "1.10.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bn4rd34368xd78bvw80hwscfgn4vmfab-cyclonedx-gomod-1.10.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bn4rd34368xd78bvw80hwscfgn4vmfab-cyclonedx-gomod-1.10.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/isdi2qqp7xvkbqxh1banvbf6d4hpfgrr-cyclonedx-gomod-1.10.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/isdi2qqp7xvkbqxh1banvbf6d4hpfgrr-cyclonedx-gomod-1.10.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5j0iybwybqmqr976yd1yqwb18qq4gg8k-cyclonedx-gomod-1.10.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5j0iybwybqmqr976yd1yqwb18qq4gg8k-cyclonedx-gomod-1.10.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hzqivlzqizb00h45a4z28vy217jn7f1y-cyclonedx-gomod-1.10.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hzqivlzqizb00h45a4z28vy217jn7f1y-cyclonedx-gomod-1.10.0"
+        }
+      }
+    },
     "delve@1.26.3": {
       "last_modified": "2026-06-27T07:37:20Z",
       "resolved": "github:NixOS/nixpkgs/3d46470bb3030020f7e1361f33514854f5bfa86d#delve",
@@ -710,8 +796,8 @@
       "resolved": "github:NixOS/nixpkgs/e318e6adc497b5e8a5ac433c6c6ed21ecdab9029?lastModified=1785082112&narHash=sha256-Y7z%2FnrPajIJyVDd9z53ZPZGm0HU%2Bkej16Pwt2cNYI0A%3D"
     },
     "github:joergdw/prspkgs#cloud-mta-build-tool": {
-      "last_modified": "2026-06-15T13:16:19Z",
-      "resolved": "github:joergdw/prspkgs/5961b9f3d253fb6b72b811fe52f431d1a211235f?lastModified=1781529379&narHash=sha256-s5vF6tmlV4L71GM3fDF%2FsPH%2FkncwkCvJ00hhDw%2F5ZIQ%3D#cloud-mta-build-tool"
+      "last_modified": "2026-07-27T11:57:25Z",
+      "resolved": "github:joergdw/prspkgs/e20208737864b1a277caa46cafd49baa8154323a?lastModified=1785153445&narHash=sha256-Tor4LdzlnY6A%2F43epc2orfMwgbn6RuWrzAZTlqn%2Fqhk%3D#cloud-mta-build-tool"
     },
     "github:joergdw/prspkgs#multiapps-cli-plugin": {
       "last_modified": "2026-06-15T13:16:19Z",

--- a/mta.tpl.yaml
+++ b/mta.tpl.yaml
@@ -97,6 +97,16 @@ modules:
         # self-sufficient. Without it, apiserver/scalingengine fail staging with
         # "no required module provides package .../apis/scalinghistory".
         - make go-mod-vendor-mta
+      # mbt's sbom-gen has no built-in BOM logic for custom builders, so generate
+      # the Go dependency SBOM here. mbt substitutes ${sbom-file-name} with the
+      # per-module BOM path it collects and merges into the aggregate SBOM
+      # (--sbom-file-path). CycloneDX 1.4 is emitted for best compatibility.
+      #
+      # TODO: `sbom-create-commands` is only honoured by mbt master (unreleased as
+      # of 1.2.49; verified skipped there). Requires mbt > 1.2.49 pulled via the
+      # joergdw/prspkgs flake in devbox.json. Until then no Go SBOM is produced.
+      sbom-create-commands:
+        - make go-sbom GO_SBOM_FILE='${sbom-file-name}'
       ignore: ["acceptance", "build", "scheduler", "dbtasks", ".devbox", ".git", ".github", "nix", ".venv", ".claude"]
     requires:
       - name: apiserver-config

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -101,35 +101,6 @@
     };
   };
 
-  cloud-mta-build-tool = buildGoModule rec {
-    pname = "Cloud MTA Build Tool";
-    version = "1.2.30";
-
-    src = fetchFromGitHub {
-      owner = "SAP";
-      repo = "cloud-mta-build-tool";
-      rev = "refs/tags/v${version}";
-      hash = "sha256-iuNaaApnyfyqm3SvYG3en+a78MUP1BxSM3JZz+JhEFs=";
-    };
-    vendorHash = "sha256-pyXeuZGg3Yv6p8GNKC598EdZqX8KLc3rkewMkq4vA7c=";
-
-    ldflags = ["-s" "-w" "-X main.Version=${version}"];
-
-    doCheck = false;
-
-    postInstall = ''
-      pushd "''${out}/bin" &> /dev/null
-      ln --symbolic 'cloud-mta-build-tool' 'mbt'
-      popd
-    '';
-
-    meta = with lib; {
-      description = "Multi-Target Application (MTA) build tool for Cloud Applications";
-      homepage = "https://sap.github.io/cloud-mta-build-tool";
-      license = licenses.asl20;
-    };
-  };
-
   log-cache-cli-plugin = buildGoModule rec {
     pname = "log-cache-cli";
     version = "6.2.1";


### PR DESCRIPTION
# Issue

`mbt sbom-gen` only produces BOMs for known builders (maven/npm). Our Go
services use `builder: custom`, which it skips ("mbt is not support it by
now"), so the Go dependency graph is absent from the merged MTA SBOM — today
it covers only the two Java modules (`dbtasks`, `scheduler`).

# Fix

Wire a `go-sbom` Makefile target (`cyclonedx-gomod`, CycloneDX 1.4) into the
apiserver module's `sbom-create-commands` in mta.tpl.yaml. mbt runs it with its
`${sbom-file-name}` placeholder, collects the output, and merges it into the
aggregate SBOM (`--sbom-file-path`) alongside the Java BOMs. Add
`cyclonedx-gomod` and `cyclonedx-cli` (mbt's merge shells out to `cyclonedx`)
to devbox, and drop the dead local `cloud-mta-build-tool` nix definition —
devbox already sources mbt from the joergdw/prspkgs flake.

`sbom-create-commands` is only on mbt master; verified empirically that both
1.2.47 and 1.2.49 still skip the module and never run `make go-sbom`. This
takes effect once devbox pulls an mbt release > 1.2.49 via the joergdw/prspkgs
flake, at which point a build should log three module SBOMs.

