### PR TITLE
chore(release): remove notification of app-autoscaler-release repo

### DIFF
--- a/.github/workflows/release-promote.yaml
+++ b/.github/workflows/release-promote.yaml
@@ -36,32 +36,3 @@ jobs:
         run: |
           git push --force-with-lease
           git push -f origin --tags
-
-      - name: Get release information
-        id: get_release
-        run: |
-          # Get the latest release (which was just published)
-          RELEASE_INFO=$(gh release view --json tagName,name,url)
-          {
-            echo "tag_name=$(echo "$RELEASE_INFO" | jq -r '.tagName')"
-            echo "release_name=$(echo "$RELEASE_INFO" | jq -r '.name')"
-            echo "release_url=$(echo "$RELEASE_INFO" | jq -r '.url')"
-            # Get the actual commit SHA that was just pushed (the version bump commit)
-            echo "commit_sha=$(git rev-parse HEAD)"
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Notify parent repository
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.PARENT_REPO_DISPATCH_TOKEN }}
-          repository: cloudfoundry/app-autoscaler-release
-          event-type: autoscaler-release-published
-          client-payload: |
-            {
-              "release_tag": "${{ steps.get_release.outputs.tag_name }}",
-              "release_name": "${{ steps.get_release.outputs.release_name }}",
-              "release_url": "${{ steps.get_release.outputs.release_url }}",
-              "commit_sha": "${{ steps.get_release.outputs.commit_sha }}"
-            }


### PR DESCRIPTION
# Issue

The release process was failing (after successful release promotion) with

<img width="836" height="123" alt="2026-07-31_15-10-30" src="https://github.com/user-attachments/assets/f49a086f-2f2f-4af4-952a-76a4e9eb427d" />

# Fix

As `app-autoscaler-release` is archived, remove the repo notification.