### PR TITLE
fix(acceptance): set autoscaling-api endpoint before querying in DebugInfo

### DIFF
--- a/acceptance/helpers/debug.go
+++ b/acceptance/helpers/debug.go
@@ -14,56 +14,51 @@ import (
 )
 
 func DebugInfo(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteSetup, anApp string) {
-	if os.Getenv("DEBUG") != "" && cfg.ASApiEndpoint != "" {
-		if os.Getenv("CF_PLUGIN_HOME") == "" {
-			_ = os.Setenv("CF_PLUGIN_HOME", os.Getenv("HOME"))
-		}
-		output := new(strings.Builder)
-		_, _ = fmt.Fprintf(output, "\n=============== DEBUG ===============\n")
-
-		// autoscaling-api writes the plugin's local config file that the other
-		// autoscaling-* commands read, so it must complete before they start.
-		waitAndPrint(startCommand("cf", "autoscaling-api", cfg.ASApiEndpoint), output)
-
-		var commands []*Session
-		commands = append(commands, startCommand("cf", "app", anApp))
-		commands = append(commands, startCommand("cf", "events", anApp))
-		commands = append(commands, startCommand("cf", "logs", "--recent", anApp))
-		commands = append(commands, startCommand("cf", "autoscaling-policy", anApp))
-		commands = append(commands, startCommand("cf", "autoscaling-history", anApp))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "memoryused"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "memoryutil"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "responsetime"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "throughput"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "cpu"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "cpuutil"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "disk"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "diskutil"))
-		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "test_metric"))
-		for _, command := range commands {
-			waitAndPrint(command, output)
-		}
-		_, _ = fmt.Fprintf(output, "\n=====================================\n")
-		GinkgoWriter.Print(output.String())
+	if os.Getenv("DEBUG") == "" || cfg.ASApiEndpoint == "" {
+		return
 	}
+	if os.Getenv("CF_PLUGIN_HOME") == "" {
+		_ = os.Setenv("CF_PLUGIN_HOME", os.Getenv("HOME"))
+	}
+	output := new(strings.Builder)
+	_, _ = fmt.Fprintf(output, "\n=============== DEBUG ===============\n")
+
+	// autoscaling-api writes the plugin's local config file that the other
+	// autoscaling-* commands read, so it must run first.
+	commands := [][]string{
+		{"autoscaling-api", cfg.ASApiEndpoint},
+		{"app", anApp},
+		{"events", anApp},
+		{"logs", "--recent", anApp},
+		{"autoscaling-policy", anApp},
+		{"autoscaling-history", anApp},
+		{"autoscaling-metrics", anApp, "memoryused"},
+		{"autoscaling-metrics", anApp, "memoryutil"},
+		{"autoscaling-metrics", anApp, "responsetime"},
+		{"autoscaling-metrics", anApp, "throughput"},
+		{"autoscaling-metrics", anApp, "cpu"},
+		{"autoscaling-metrics", anApp, "cpuutil"},
+		{"autoscaling-metrics", anApp, "disk"},
+		{"autoscaling-metrics", anApp, "diskutil"},
+		{"autoscaling-metrics", anApp, "test_metric"},
+	}
+	for _, args := range commands {
+		runAndPrint(output, "cf", args...)
+	}
+	_, _ = fmt.Fprintf(output, "\n=====================================\n")
+	GinkgoWriter.Print(output.String())
 }
 
-// waitAndPrint waits for the command to finish and appends its invocation and
+// runAndPrint runs the command to completion and appends its invocation and
 // stdout/stderr to output.
-func waitAndPrint(command *Session, output *strings.Builder) {
-	command.Wait(30 * time.Second)
-	_, _ = fmt.Fprintln(output, strings.Join(command.Command.Args, " ")+":")
-	_, _ = fmt.Fprintln(output, string(command.Out.Contents()))
-	_, _ = fmt.Fprintln(output, string(command.Err.Contents()))
-}
-
-// startCommand launches the command asynchronously and returns the running
-// session; use waitAndPrint to wait for it and capture its output.
-func startCommand(name string, args ...string) *Session {
-	cmd := exec.Command(name, args...)
-	start, err := Start(cmd, nil, nil)
+func runAndPrint(output *strings.Builder, name string, args ...string) {
+	session, err := Start(exec.Command(name, args...), nil, nil)
 	if err != nil {
 		GinkgoWriter.Println(err.Error())
+		return
 	}
-	return start
+	session.Wait(30 * time.Second)
+	_, _ = fmt.Fprintln(output, strings.Join(session.Command.Args, " ")+":")
+	_, _ = fmt.Fprintln(output, string(session.Out.Contents()))
+	_, _ = fmt.Fprintln(output, string(session.Err.Contents()))
 }

--- a/acceptance/helpers/debug.go
+++ b/acceptance/helpers/debug.go
@@ -23,23 +23,23 @@ func DebugInfo(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteS
 
 		// autoscaling-api writes the plugin's local config file that the other
 		// autoscaling-* commands read, so it must complete before they start.
-		waitAndPrint(command("cf", "autoscaling-api", cfg.ASApiEndpoint), output)
+		waitAndPrint(startCommand("cf", "autoscaling-api", cfg.ASApiEndpoint), output)
 
 		var commands []*Session
-		commands = append(commands, command("cf", "app", anApp))
-		commands = append(commands, command("cf", "events", anApp))
-		commands = append(commands, command("cf", "logs", "--recent", anApp))
-		commands = append(commands, command("cf", "autoscaling-policy", anApp))
-		commands = append(commands, command("cf", "autoscaling-history", anApp))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "memoryused"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "memoryutil"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "responsetime"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "throughput"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "cpu"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "cpuutil"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "disk"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "diskutil"))
-		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "test_metric"))
+		commands = append(commands, startCommand("cf", "app", anApp))
+		commands = append(commands, startCommand("cf", "events", anApp))
+		commands = append(commands, startCommand("cf", "logs", "--recent", anApp))
+		commands = append(commands, startCommand("cf", "autoscaling-policy", anApp))
+		commands = append(commands, startCommand("cf", "autoscaling-history", anApp))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "memoryused"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "memoryutil"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "responsetime"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "throughput"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "cpu"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "cpuutil"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "disk"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "diskutil"))
+		commands = append(commands, startCommand("cf", "autoscaling-metrics", anApp, "test_metric"))
 		for _, command := range commands {
 			waitAndPrint(command, output)
 		}
@@ -57,7 +57,9 @@ func waitAndPrint(command *Session, output *strings.Builder) {
 	_, _ = fmt.Fprintln(output, string(command.Err.Contents()))
 }
 
-func command(name string, args ...string) *Session {
+// startCommand launches the command asynchronously and returns the running
+// session; use waitAndPrint to wait for it and capture its output.
+func startCommand(name string, args ...string) *Session {
 	cmd := exec.Command(name, args...)
 	start, err := Start(cmd, nil, nil)
 	if err != nil {

--- a/acceptance/helpers/debug.go
+++ b/acceptance/helpers/debug.go
@@ -18,11 +18,17 @@ func DebugInfo(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteS
 		if os.Getenv("CF_PLUGIN_HOME") == "" {
 			_ = os.Setenv("CF_PLUGIN_HOME", os.Getenv("HOME"))
 		}
+		output := new(strings.Builder)
+		_, _ = fmt.Fprintf(output, "\n=============== DEBUG ===============\n")
+
+		// autoscaling-api writes the plugin's local config file that the other
+		// autoscaling-* commands read, so it must complete before they start.
+		waitAndPrint(command("cf", "autoscaling-api", cfg.ASApiEndpoint), output)
+
 		var commands []*Session
 		commands = append(commands, command("cf", "app", anApp))
 		commands = append(commands, command("cf", "events", anApp))
 		commands = append(commands, command("cf", "logs", "--recent", anApp))
-		commands = append(commands, command("cf", "autoscaling-api", cfg.ASApiEndpoint))
 		commands = append(commands, command("cf", "autoscaling-policy", anApp))
 		commands = append(commands, command("cf", "autoscaling-history", anApp))
 		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "memoryused"))
@@ -34,17 +40,21 @@ func DebugInfo(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteS
 		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "disk"))
 		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "diskutil"))
 		commands = append(commands, command("cf", "autoscaling-metrics", anApp, "test_metric"))
-		output := new(strings.Builder)
-		_, _ = fmt.Fprintf(output, "\n=============== DEBUG ===============\n")
 		for _, command := range commands {
-			command.Wait(30 * time.Second)
-			_, _ = fmt.Fprintln(output, strings.Join(command.Command.Args, " ")+":")
-			_, _ = fmt.Fprintln(output, string(command.Out.Contents()))
-			_, _ = fmt.Fprintln(output, string(command.Err.Contents()))
+			waitAndPrint(command, output)
 		}
 		_, _ = fmt.Fprintf(output, "\n=====================================\n")
 		GinkgoWriter.Print(output.String())
 	}
+}
+
+// waitAndPrint waits for the command to finish and appends its invocation and
+// stdout/stderr to output.
+func waitAndPrint(command *Session, output *strings.Builder) {
+	command.Wait(30 * time.Second)
+	_, _ = fmt.Fprintln(output, strings.Join(command.Command.Args, " ")+":")
+	_, _ = fmt.Fprintln(output, string(command.Out.Contents()))
+	_, _ = fmt.Fprintln(output, string(command.Err.Contents()))
 }
 
 func command(name string, args ...string) *Session {


### PR DESCRIPTION
# Issue

Occasionally we instead of debug output on app suite failures we saw `No AutoScaler api endpoint set.` instead, see #1355.

`DebugInfo` launched all 15 `cf` commands concurrently; `cf autoscaling-api <endpoint>` writes the CF plugin's local config file while `autoscaling-history` and `autoscaling-metrics` commands were already running and reading it creating a race condition.

# Fix
Run commands sequentially.

Fixes: #1355 