### PR TITLE
fix(metricsforwarder): stop sharing mutable allowed-metric cache maps

### DIFF
--- a/metricsforwarder/cache/allowed_metric_cache.go
+++ b/metricsforwarder/cache/allowed_metric_cache.go
@@ -1,0 +1,63 @@
+package cache
+
+import (
+	"maps"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+// AllowedMetricCache wraps go-cache for the allowed-metric type sets.
+// go-cache returns stored values by reference, so every read and write
+// clones the map. This keeps the clone-on-read / clone-on-write invariant
+// in one place: callers can never accidentally share a mutable map with
+// the cache.
+type AllowedMetricCache struct {
+	c *gocache.Cache
+}
+
+func New(ttl, cleanupInterval time.Duration) *AllowedMetricCache {
+	return &AllowedMetricCache{c: gocache.New(ttl, cleanupInterval)}
+}
+
+// Get returns a clone of the cached set, so callers may freely mutate it.
+func (a *AllowedMetricCache) Get(appID string) (map[string]struct{}, bool) {
+	v, found := a.c.Get(appID)
+	if !found {
+		return nil, false
+	}
+	m, ok := v.(map[string]struct{})
+	if !ok {
+		return nil, false
+	}
+	return maps.Clone(m), true
+}
+
+// Set stores a clone, so later mutation of the input does not affect the cache.
+func (a *AllowedMetricCache) Set(appID string, m map[string]struct{}, ttl time.Duration) {
+	a.c.Set(appID, maps.Clone(m), ttl)
+}
+
+// Replace stores a clone, so later mutation of the input does not affect the cache.
+func (a *AllowedMetricCache) Replace(appID string, m map[string]struct{}, ttl time.Duration) error {
+	return a.c.Replace(appID, maps.Clone(m), ttl)
+}
+
+func (a *AllowedMetricCache) Delete(appID string) {
+	a.c.Delete(appID)
+}
+
+// AppIDs returns the cached app IDs. It fully encapsulates gocache.Item so it
+// never leaks through the wrapper.
+func (a *AllowedMetricCache) AppIDs() []string {
+	items := a.c.Items()
+	ids := make([]string, 0, len(items))
+	for id := range items {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (a *AllowedMetricCache) Flush() {
+	a.c.Flush()
+}

--- a/metricsforwarder/cache/allowed_metric_cache_suite_test.go
+++ b/metricsforwarder/cache/allowed_metric_cache_suite_test.go
@@ -1,0 +1,13 @@
+package cache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AllowedMetricCache Suite")
+}

--- a/metricsforwarder/cache/allowed_metric_cache_test.go
+++ b/metricsforwarder/cache/allowed_metric_cache_test.go
@@ -1,0 +1,132 @@
+package cache_test
+
+import (
+	"sync"
+	"time"
+
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AllowedMetricCache", func() {
+	var c *mfcache.AllowedMetricCache
+
+	BeforeEach(func() {
+		c = mfcache.New(10*time.Minute, -1)
+	})
+
+	Describe("Get", func() {
+		It("returns a clone so mutating the result does not affect the cached value", func() {
+			c.Set("app", map[string]struct{}{"metric-a": {}}, 10*time.Minute)
+
+			got, found := c.Get("app")
+			Expect(found).To(BeTrue())
+			Expect(got).To(HaveKey("metric-a"))
+
+			// Mutate the returned map.
+			got["metric-b"] = struct{}{}
+
+			// The cached value must be unaffected.
+			again, found := c.Get("app")
+			Expect(found).To(BeTrue())
+			Expect(again).To(HaveKey("metric-a"))
+			Expect(again).NotTo(HaveKey("metric-b"))
+		})
+
+		It("returns (nil, false) on a miss", func() {
+			got, found := c.Get("missing")
+			Expect(found).To(BeFalse())
+			Expect(got).To(BeNil())
+		})
+	})
+
+	Describe("Set", func() {
+		It("stores a clone so mutating the input after Set does not affect the cached value", func() {
+			in := map[string]struct{}{"metric-a": {}}
+			c.Set("app", in, 10*time.Minute)
+
+			// Mutate the input after Set.
+			in["metric-b"] = struct{}{}
+
+			got, found := c.Get("app")
+			Expect(found).To(BeTrue())
+			Expect(got).To(HaveKey("metric-a"))
+			Expect(got).NotTo(HaveKey("metric-b"))
+		})
+	})
+
+	Describe("Replace", func() {
+		It("stores a clone so mutating the input after Replace does not affect the cached value", func() {
+			c.Set("app", map[string]struct{}{"metric-a": {}}, 10*time.Minute)
+
+			in := map[string]struct{}{"metric-b": {}}
+			Expect(c.Replace("app", in, 10*time.Minute)).To(Succeed())
+
+			// Mutate the input after Replace.
+			in["metric-c"] = struct{}{}
+
+			got, found := c.Get("app")
+			Expect(found).To(BeTrue())
+			Expect(got).To(HaveKey("metric-b"))
+			Expect(got).NotTo(HaveKey("metric-c"))
+			Expect(got).NotTo(HaveKey("metric-a"))
+		})
+	})
+
+	Describe("AppIDs", func() {
+		It("returns the cached app IDs", func() {
+			c.Set("app-a", map[string]struct{}{}, 10*time.Minute)
+			c.Set("app-b", map[string]struct{}{}, 10*time.Minute)
+
+			Expect(c.AppIDs()).To(ConsistOf("app-a", "app-b"))
+		})
+	})
+
+	Describe("Delete", func() {
+		It("removes the entry", func() {
+			c.Set("app", map[string]struct{}{"metric-a": {}}, 10*time.Minute)
+			c.Delete("app")
+
+			_, found := c.Get("app")
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	Describe("Flush", func() {
+		It("removes all entries", func() {
+			c.Set("app-a", map[string]struct{}{}, 10*time.Minute)
+			c.Set("app-b", map[string]struct{}{}, 10*time.Minute)
+			c.Flush()
+
+			Expect(c.AppIDs()).To(BeEmpty())
+		})
+	})
+
+	Describe("concurrent Get and Set", func() {
+		It("does not race", func() {
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 1000; i++ {
+					c.Set("app", map[string]struct{}{"metric-a": {}}, 10*time.Minute)
+				}
+			}()
+
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 1000; i++ {
+					if got, found := c.Get("app"); found {
+						// Mutate the clone to prove readers own their copy.
+						got["reader-local"] = struct{}{}
+					}
+				}
+			}()
+
+			wg.Wait()
+		})
+	})
+})

--- a/metricsforwarder/cmd/metricsforwarder/main.go
+++ b/metricsforwarder/cmd/metricsforwarder/main.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db/sqldb"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/healthendpoint"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/config"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/manager"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/server"
@@ -16,7 +17,6 @@ import (
 
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/patrickmn/go-cache"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
 )
@@ -57,7 +57,7 @@ func main() {
 
 	httpStatusCollector := healthendpoint.NewHTTPStatusCollector("autoscaler", "metricsforwarder")
 
-	allowedMetricCache := cache.New(conf.CacheTTL, conf.CacheCleanupInterval)
+	allowedMetricCache := mfcache.New(conf.CacheTTL, conf.CacheCleanupInterval)
 	customMetricsServer := createCustomMetricsServer(conf, logger, policyDb, bindingDB, credentialProvider, allowedMetricCache, httpStatusCollector)
 	cacheUpdater := cacheUpdater(logger, mfClock, conf, policyDb, allowedMetricCache)
 
@@ -72,8 +72,8 @@ func main() {
 	}
 }
 
-func cacheUpdater(logger lager.Logger, mfClock clock.Clock, conf *config.Config, policyDB *sqldb.PolicySQLDB, allowedMetricCache *cache.Cache) ifrit.RunFunc {
-	policyManager := manager.NewPolicyManager(logger, mfClock, conf.PolicyPollerInterval, policyDB, *allowedMetricCache, conf.CacheTTL)
+func cacheUpdater(logger lager.Logger, mfClock clock.Clock, conf *config.Config, policyDB *sqldb.PolicySQLDB, allowedMetricCache *mfcache.AllowedMetricCache) ifrit.RunFunc {
+	policyManager := manager.NewPolicyManager(logger, mfClock, conf.PolicyPollerInterval, policyDB, allowedMetricCache, conf.CacheTTL)
 	cacheUpdater := ifrit.RunFunc(func(signals <-chan os.Signal, ready chan<- struct{}) error {
 		policyManager.Start()
 		close(ready)
@@ -84,9 +84,9 @@ func cacheUpdater(logger lager.Logger, mfClock clock.Clock, conf *config.Config,
 	return cacheUpdater
 }
 
-func createCustomMetricsServer(conf *config.Config, logger lager.Logger, policyDB *sqldb.PolicySQLDB, bindingDB *sqldb.BindingSQLDB, credentialProvider cred_helper.Credentials, allowedMetricCache *cache.Cache, httpStatusCollector healthendpoint.HTTPStatusCollector) ifrit.Runner {
+func createCustomMetricsServer(conf *config.Config, logger lager.Logger, policyDB *sqldb.PolicySQLDB, bindingDB *sqldb.BindingSQLDB, credentialProvider cred_helper.Credentials, allowedMetricCache *mfcache.AllowedMetricCache, httpStatusCollector healthendpoint.HTTPStatusCollector) ifrit.Runner {
 	rateLimiter := ratelimiter.DefaultRateLimiter(conf.RateLimit.MaxAmount, conf.RateLimit.ValidDuration, logger.Session("metricforwarder-ratelimiter"))
-	httpServer, err := server.NewServer(logger.Session("custom_metrics_server"), conf, policyDB, bindingDB, credentialProvider, *allowedMetricCache, httpStatusCollector, rateLimiter)
+	httpServer, err := server.NewServer(logger.Session("custom_metrics_server"), conf, policyDB, bindingDB, credentialProvider, allowedMetricCache, httpStatusCollector, rateLimiter)
 	startup.ExitOnError(err, logger, "Failed to create client to custom metrics server")
 	return httpServer
 }

--- a/metricsforwarder/manager/policyManager.go
+++ b/metricsforwarder/manager/policyManager.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/patrickmn/go-cache"
 )
 
 type Consumer func(map[string]*models.AppPolicy, chan *models.AppMonitor)
@@ -18,7 +18,7 @@ type PolicyManager struct {
 	logger             lager.Logger
 	interval           time.Duration
 	cacheTTL           time.Duration
-	allowedMetricCache cache.Cache
+	allowedMetricCache *mfcache.AllowedMetricCache
 	database           db.PolicyDB
 	clock              clock.Clock
 	doneChan           chan bool
@@ -28,7 +28,7 @@ type PolicyManager struct {
 }
 
 func NewPolicyManager(logger lager.Logger, clock clock.Clock, interval time.Duration,
-	database db.PolicyDB, allowedMetricCache cache.Cache, cacheTTL time.Duration) *PolicyManager {
+	database db.PolicyDB, allowedMetricCache *mfcache.AllowedMetricCache, cacheTTL time.Duration) *PolicyManager {
 	return &PolicyManager{
 		logger:             logger.Session("PolicyManager"),
 		clock:              clock,
@@ -104,12 +104,9 @@ func (pm *PolicyManager) computePolicies(policyJsons []*models.PolicyJson) map[s
 func (pm *PolicyManager) RefreshAllowedMetricCache(policies map[string]*models.AppPolicy) error {
 	pm.mLock.Lock()
 	defer pm.mLock.Unlock()
-	allowedMetricMap := pm.allowedMetricCache.Items()
 	//Iterating over the cache and replace the allowed metrics for existing policy
-	for applicationId := range allowedMetricMap {
+	for _, applicationId := range pm.allowedMetricCache.AppIDs() {
 		if policy, ok := policies[applicationId]; ok {
-			// Build a fresh set per app: entries must not alias one shared map,
-			// which the loop would keep mutating while readers iterate it.
 			allowedMetricTypeSet := make(map[string]struct{})
 			scalingPolicy := policy.ScalingPolicy
 			for _, metrictype := range scalingPolicy.ScalingRules {

--- a/metricsforwarder/manager/policyManager.go
+++ b/metricsforwarder/manager/policyManager.go
@@ -104,11 +104,13 @@ func (pm *PolicyManager) computePolicies(policyJsons []*models.PolicyJson) map[s
 func (pm *PolicyManager) RefreshAllowedMetricCache(policies map[string]*models.AppPolicy) error {
 	pm.mLock.Lock()
 	defer pm.mLock.Unlock()
-	allowedMetricTypeSet := make(map[string]struct{})
 	allowedMetricMap := pm.allowedMetricCache.Items()
 	//Iterating over the cache and replace the allowed metrics for existing policy
 	for applicationId := range allowedMetricMap {
 		if policy, ok := policies[applicationId]; ok {
+			// Build a fresh set per app: entries must not alias one shared map,
+			// which the loop would keep mutating while readers iterate it.
+			allowedMetricTypeSet := make(map[string]struct{})
 			scalingPolicy := policy.ScalingPolicy
 			for _, metrictype := range scalingPolicy.ScalingRules {
 				allowedMetricTypeSet[metrictype.MetricType] = struct{}{}

--- a/metricsforwarder/manager/policyManager_test.go
+++ b/metricsforwarder/manager/policyManager_test.go
@@ -1,6 +1,8 @@
 package manager_test
 
 import (
+	"encoding/json"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/fakes"
@@ -165,6 +167,83 @@ var _ = Describe("PolicyManager", func() {
 		It("stops the polling", func() {
 			clock.Increment(5 * testPolicyPollerInterval)
 			Consistently(database.RetrievePoliciesCallCount).Should(Or(Equal(1), Equal(2)))
+		})
+	})
+
+	Context("RefreshAllowedMetricCache concurrency", func() {
+		// Regression: RefreshAllowedMetricCache built a single allowedMetricTypeSet
+		// map and Replace'd that same instance into the cache for every app, so
+		// all entries aliased one shared map that the refresh loop kept mutating.
+		// A concurrent reader (e.g. json.Marshal of the set for logging) then
+		// iterated a map being written, crashing the process with
+		// "fatal error: concurrent map iteration and map write".
+		var (
+			appA = "app-a"
+			appB = "app-b"
+		)
+
+		BeforeEach(func() {
+			policyManager = NewPolicyManager(logger, clock, testPolicyPollerInterval, database, allowedMetricCache, 10*time.Minute)
+			// Seed two apps so the refresh loop iterates more than one entry.
+			allowedMetricCache.Set(appA, make(map[string]struct{}), 10*time.Minute)
+			allowedMetricCache.Set(appB, make(map[string]struct{}), 10*time.Minute)
+		})
+
+		It("gives each app its own metric set", func() {
+			policies := map[string]*models.AppPolicy{
+				appA: {AppId: appA, ScalingPolicy: &models.PolicyDefinition{
+					ScalingRules: []*models.ScalingRule{{MetricType: "metric-a"}}}},
+				appB: {AppId: appB, ScalingPolicy: &models.PolicyDefinition{
+					ScalingRules: []*models.ScalingRule{{MetricType: "metric-b"}}}},
+			}
+			Expect(policyManager.RefreshAllowedMetricCache(policies)).To(Succeed())
+
+			resA, foundA := allowedMetricCache.Get(appA)
+			Expect(foundA).To(BeTrue())
+			resB, foundB := allowedMetricCache.Get(appB)
+			Expect(foundB).To(BeTrue())
+
+			// Each entry must contain only its own app's metric, not a shared
+			// union of both.
+			Expect(resA.(map[string]struct{})).To(HaveKey("metric-a"))
+			Expect(resA.(map[string]struct{})).NotTo(HaveKey("metric-b"))
+			Expect(resB.(map[string]struct{})).To(HaveKey("metric-b"))
+			Expect(resB.(map[string]struct{})).NotTo(HaveKey("metric-a"))
+		})
+
+		It("does not race with a concurrent reader of the cached set", func() {
+			// Under `go test -race` this trips the detector (and the fatal
+			// "concurrent map iteration and map write") when the refresh loop
+			// mutates a map another goroutine is marshalling.
+			policies := map[string]*models.AppPolicy{
+				appA: {AppId: appA, ScalingPolicy: &models.PolicyDefinition{
+					ScalingRules: []*models.ScalingRule{{MetricType: "metric-a"}}}},
+				appB: {AppId: appB, ScalingPolicy: &models.PolicyDefinition{
+					ScalingRules: []*models.ScalingRule{{MetricType: "metric-b"}}}},
+			}
+
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						if res, found := allowedMetricCache.Get(appA); found {
+							_, _ = json.Marshal(res)
+						}
+					}
+				}
+			}()
+
+			for i := 0; i < 1000; i++ {
+				Expect(policyManager.RefreshAllowedMetricCache(policies)).To(Succeed())
+			}
+			close(stop)
+			wg.Wait()
 		})
 	})
 })

--- a/metricsforwarder/manager/policyManager_test.go
+++ b/metricsforwarder/manager/policyManager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/fakes"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	. "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/manager"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
@@ -13,7 +14,6 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/patrickmn/go-cache"
 )
 
 var _ = Describe("PolicyManager", func() {
@@ -22,7 +22,7 @@ var _ = Describe("PolicyManager", func() {
 		clock                    *fakeclock.FakeClock
 		policyManager            *PolicyManager
 		testPolicyPollerInterval time.Duration
-		allowedMetricCache       cache.Cache
+		allowedMetricCache       *mfcache.AllowedMetricCache
 		allowedMetricTypeSet     map[string]struct{}
 		policyMap                map[string]*models.AppPolicy
 		logger                   lager.Logger
@@ -50,7 +50,7 @@ var _ = Describe("PolicyManager", func() {
 		database = &fakes.FakePolicyDB{}
 		clock = fakeclock.NewFakeClock(time.Now())
 		testPolicyPollerInterval = 1 * time.Second
-		allowedMetricCache = *cache.New(10*time.Minute, -1)
+		allowedMetricCache = mfcache.New(10*time.Minute, -1)
 		logger = lager.NewLogger("policyManager-test")
 		policyMap = make(map[string]*models.AppPolicy)
 		allowedMetricTypeSet = make(map[string]struct{})
@@ -112,9 +112,9 @@ var _ = Describe("PolicyManager", func() {
 				allowedMetricCache.Set(testAppId, allowedMetricTypeSet, 10*time.Minute)
 
 				res, found := allowedMetricCache.Get(testAppId)
-				maps := res.(map[string]struct{})
+				allowedMetrics := res
 				Expect(found).To(BeTrue())
-				Expect(maps).Should(HaveKey("queuelength"))
+				Expect(allowedMetrics).Should(HaveKey("queuelength"))
 
 			})
 
@@ -130,11 +130,11 @@ var _ = Describe("PolicyManager", func() {
 					Eventually(database.RetrievePoliciesCallCount).Should(Equal(2))
 
 					res, found := allowedMetricCache.Get(testAppId)
-					maps := res.(map[string]struct{})
+					allowedMetrics := res
 
 					Expect(found).To(BeTrue())
-					Expect(maps).Should(HaveKey("test-metric-name"))
-					Expect(maps).ShouldNot(HaveKey("queuelength"))
+					Expect(allowedMetrics).Should(HaveKey("test-metric-name"))
+					Expect(allowedMetrics).ShouldNot(HaveKey("queuelength"))
 				})
 			})
 			When("the policy is deleted", func() {
@@ -205,10 +205,10 @@ var _ = Describe("PolicyManager", func() {
 
 			// Each entry must contain only its own app's metric, not a shared
 			// union of both.
-			Expect(resA.(map[string]struct{})).To(HaveKey("metric-a"))
-			Expect(resA.(map[string]struct{})).NotTo(HaveKey("metric-b"))
-			Expect(resB.(map[string]struct{})).To(HaveKey("metric-b"))
-			Expect(resB.(map[string]struct{})).NotTo(HaveKey("metric-a"))
+			Expect(resA).To(HaveKey("metric-a"))
+			Expect(resA).NotTo(HaveKey("metric-b"))
+			Expect(resB).To(HaveKey("metric-b"))
+			Expect(resB).NotTo(HaveKey("metric-a"))
 		})
 
 		It("does not race with a concurrent reader of the cached set", func() {

--- a/metricsforwarder/server/auth/auth_suite_test.go
+++ b/metricsforwarder/server/auth/auth_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/fakes"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/helpers"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/config"
 	. "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/server"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
@@ -31,7 +32,7 @@ var (
 	fakeCredentials *fakes.FakeCredentials
 
 	credentialCache    cache.Cache
-	allowedMetricCache cache.Cache
+	allowedMetricCache *mfcache.AllowedMetricCache
 )
 
 func TestAuth(t *testing.T) {
@@ -78,7 +79,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	policyDB = &fakes.FakePolicyDB{}
 	fakeBindingDB = &fakes.FakeBindingDB{}
 	credentialCache = *cache.New(10*time.Minute, -1)
-	allowedMetricCache = *cache.New(10*time.Minute, -1)
+	allowedMetricCache = mfcache.New(10*time.Minute, -1)
 	httpStatusCollector := &fakes.FakeHTTPStatusCollector{}
 	rateLimiter = &fakes.FakeLimiter{}
 	fakeCredentials = &fakes.FakeCredentials{}

--- a/metricsforwarder/server/custom_metrics_handlers.go
+++ b/metricsforwarder/server/custom_metrics_handlers.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/forwarder"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
@@ -17,7 +17,6 @@ import (
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/helpers/handlers"
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/patrickmn/go-cache"
 )
 
 var (
@@ -30,12 +29,12 @@ type CustomMetricsHandler struct {
 	metricForwarder    forwarder.MetricForwarder
 	policyDB           db.PolicyDB
 	bindingDB          db.BindingDB
-	allowedMetricCache cache.Cache
+	allowedMetricCache *mfcache.AllowedMetricCache
 	cacheTTL           time.Duration
 	logger             lager.Logger
 }
 
-func NewCustomMetricsHandler(logger lager.Logger, metricForwarder forwarder.MetricForwarder, policyDB db.PolicyDB, bindingDB db.BindingDB, allowedMetricCache cache.Cache) *CustomMetricsHandler {
+func NewCustomMetricsHandler(logger lager.Logger, metricForwarder forwarder.MetricForwarder, policyDB db.PolicyDB, bindingDB db.BindingDB, allowedMetricCache *mfcache.AllowedMetricCache) *CustomMetricsHandler {
 	return &CustomMetricsHandler{
 		metricForwarder:    metricForwarder,
 		policyDB:           policyDB,
@@ -138,10 +137,8 @@ func (mh *CustomMetricsHandler) validateCustomMetricTypes(appGUID string, metric
 	allowedMetricTypeSet := make(map[string]struct{})
 	res, found := mh.allowedMetricCache.Get(appGUID)
 	if found {
-		// AllowedMetrics found in cache. Clone into a locally-owned map: the
-		// cached instance must be treated as read-only, since a concurrent
-		// cache refresh may share or replace it while we read/marshal it.
-		allowedMetricTypeSet = maps.Clone(res.(map[string]struct{}))
+		// AllowedMetrics found in cache
+		allowedMetricTypeSet = res
 	} else {
 		// allow app with strategy as bound_app to submit metrics without policy
 		isAppWithBoundStrategy, err := mh.isAppWithBoundStrategy(appGUID)
@@ -166,9 +163,8 @@ func (mh *CustomMetricsHandler) validateCustomMetricTypes(appGUID string, metric
 		for _, metrictype := range scalingPolicy.ScalingRules {
 			allowedMetricTypeSet[metrictype.MetricType] = struct{}{}
 		}
-		// Cache a copy so later mutation of our local map cannot reach into
-		// the cached entry (and vice versa).
-		mh.allowedMetricCache.Set(appGUID, maps.Clone(allowedMetricTypeSet), mh.cacheTTL)
+		//update the cache
+		mh.allowedMetricCache.Set(appGUID, allowedMetricTypeSet, mh.cacheTTL)
 	}
 	mh.logger.Debug("allowed-metrics-types", lager.Data{"metrics": allowedMetricTypeSet})
 	for _, metric := range metricsConsumer.CustomMetrics {

--- a/metricsforwarder/server/custom_metrics_handlers.go
+++ b/metricsforwarder/server/custom_metrics_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/forwarder"
@@ -137,8 +138,10 @@ func (mh *CustomMetricsHandler) validateCustomMetricTypes(appGUID string, metric
 	allowedMetricTypeSet := make(map[string]struct{})
 	res, found := mh.allowedMetricCache.Get(appGUID)
 	if found {
-		// AllowedMetrics found in cache
-		allowedMetricTypeSet = res.(map[string]struct{})
+		// AllowedMetrics found in cache. Clone into a locally-owned map: the
+		// cached instance must be treated as read-only, since a concurrent
+		// cache refresh may share or replace it while we read/marshal it.
+		allowedMetricTypeSet = maps.Clone(res.(map[string]struct{}))
 	} else {
 		// allow app with strategy as bound_app to submit metrics without policy
 		isAppWithBoundStrategy, err := mh.isAppWithBoundStrategy(appGUID)
@@ -163,8 +166,9 @@ func (mh *CustomMetricsHandler) validateCustomMetricTypes(appGUID string, metric
 		for _, metrictype := range scalingPolicy.ScalingRules {
 			allowedMetricTypeSet[metrictype.MetricType] = struct{}{}
 		}
-		//update the cache
-		mh.allowedMetricCache.Set(appGUID, allowedMetricTypeSet, mh.cacheTTL)
+		// Cache a copy so later mutation of our local map cannot reach into
+		// the cached entry (and vice versa).
+		mh.allowedMetricCache.Set(appGUID, maps.Clone(allowedMetricTypeSet), mh.cacheTTL)
 	}
 	mh.logger.Debug("allowed-metrics-types", lager.Data{"metrics": allowedMetricTypeSet})
 	for _, metric := range metricsConsumer.CustomMetrics {

--- a/metricsforwarder/server/custom_metrics_handlers_test.go
+++ b/metricsforwarder/server/custom_metrics_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/fakes"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	. "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/server"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
@@ -17,8 +18,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-
-	"github.com/patrickmn/go-cache"
 )
 
 var _ = Describe("MetricHandler", func() {
@@ -26,7 +25,7 @@ var _ = Describe("MetricHandler", func() {
 	var (
 		handler *CustomMetricsHandler
 
-		allowedMetricCache cache.Cache
+		allowedMetricCache *mfcache.AllowedMetricCache
 
 		allowedMetricTypeSet map[string]struct{}
 
@@ -52,7 +51,7 @@ var _ = Describe("MetricHandler", func() {
 		policyDB = &fakes.FakePolicyDB{}
 		fakeBindingDB = &fakes.FakeBindingDB{}
 		metricsforwarder = &fakes.FakeMetricForwarder{}
-		allowedMetricCache = *cache.New(10*time.Minute, -1)
+		allowedMetricCache = mfcache.New(10*time.Minute, -1)
 		allowedMetricTypeSet = make(map[string]struct{})
 		vars = make(map[string]string)
 		resp = httptest.NewRecorder()

--- a/metricsforwarder/server/server.go
+++ b/metricsforwarder/server/server.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/healthendpoint"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/helpers"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/config"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/forwarder"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/server/auth"
@@ -18,12 +19,11 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/gorilla/mux"
-	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tedsuo/ifrit"
 )
 
-func NewServer(logger lager.Logger, conf *config.Config, policyDb db.PolicyDB, bindingDB db.BindingDB, credentials cred_helper.Credentials, allowedMetricCache cache.Cache, httpStatusCollector healthendpoint.HTTPStatusCollector, rateLimiter ratelimiter.Limiter) (ifrit.Runner, error) {
+func NewServer(logger lager.Logger, conf *config.Config, policyDb db.PolicyDB, bindingDB db.BindingDB, credentials cred_helper.Credentials, allowedMetricCache *mfcache.AllowedMetricCache, httpStatusCollector healthendpoint.HTTPStatusCollector, rateLimiter ratelimiter.Limiter) (ifrit.Runner, error) {
 	metricForwarder, err := createMetricForwarder(logger, conf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric forwarder: %w", err)

--- a/metricsforwarder/server/server_suite_test.go
+++ b/metricsforwarder/server/server_suite_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/fakes"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/healthendpoint"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/helpers"
+	mfcache "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cache"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/config"
 	. "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/server"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
@@ -15,7 +16,6 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/patrickmn/go-cache"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/ginkgomon_v2"
 
@@ -31,7 +31,7 @@ var (
 	rateLimiter     *fakes.FakeLimiter
 	fakeCredentials *fakes.FakeCredentials
 
-	allowedMetricCache cache.Cache
+	allowedMetricCache *mfcache.AllowedMetricCache
 )
 
 func TestServer(t *testing.T) {
@@ -86,7 +86,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	policyDB = &fakes.FakePolicyDB{}
 	fakeBindingDB = &fakes.FakeBindingDB{}
 
-	allowedMetricCache = *cache.New(10*time.Minute, -1)
+	allowedMetricCache = mfcache.New(10*time.Minute, -1)
 	httpStatusCollector := healthendpoint.NewHTTPStatusCollector("autoscaler", "metricsforwarder")
 
 	rateLimiter = &fakes.FakeLimiter{}


### PR DESCRIPTION
# Issue

Cached `map[string]struct{}` allowed-metric sets were shared and mutated
concurrently, crashing the process:

```
fatal error: concurrent map iteration and map write
```

Two sites were at fault:

- `RefreshAllowedMetricCache` allocated one set outside the per-app loop
  and `Replace`d that same instance for every app, so all cache entries
  aliased one map the loop kept writing to.
- `validateCustomMetricTypes` aliased the cached map on a hit (and stored
  the instance it built on a miss) and then marshalled it for debug
  logging, iterating a map the refresh loop was writing.

# Fix

Treat cached sets as immutable snapshots:

- refresh allocates a fresh set per app inside the loop,
- the handler `maps.Clone`s the cached set into a locally-owned map on a
  hit and caches a clone on a miss, so no goroutine ever writes a map
  another reads.

Covered by new concurrency specs on `RefreshAllowedMetricCache` that pass
under `-race`.