### PR TITLE
fix(mta): increase Go module memory from 1G to 1500M - prevent OOM

### DIFF
--- a/mta.tpl.yaml
+++ b/mta.tpl.yaml
@@ -106,7 +106,7 @@ modules:
       - name: app-autoscaler-dynatrace
     parameters:
       instances: 0 # overridden in build-extension-file.sh
-      memory: 1G
+      memory: 1500M
       disk-quota: 1G
       stack: cflinuxfs4
       routes:
@@ -132,7 +132,7 @@ modules:
       - name: app-autoscaler-dynatrace
     parameters:
       instances: 0 # overridden in build-extension-file.sh
-      memory: 1G
+      memory: 1500M
       disk-quota: 1G
       stack: cflinuxfs4
       routes:
@@ -159,7 +159,7 @@ modules:
       - name: app-autoscaler-dynatrace
     parameters:
       instances: 0 # overridden in build-extension-file.sh
-      memory: 1G
+      memory: 1500M
       disk-quota: 1G
       stack: cflinuxfs4
       routes:
@@ -185,7 +185,7 @@ modules:
       - name: app-autoscaler-dynatrace
     parameters:
       instances: 0 # overridden in build-extension-file.sh
-      memory: 256M
+      memory: 1500M
       disk-quota: 512M
       stack: cflinuxfs4
       routes:
@@ -211,7 +211,7 @@ modules:
       - name: app-autoscaler-dynatrace
     parameters:
       instances: 0 # overridden in build-extension-file.sh
-      memory: 1G
+      memory: 1500M
       disk-quota: 1G
       stack: cflinuxfs4
       routes:
@@ -237,7 +237,7 @@ modules:
       - name: app-autoscaler-dynatrace
     parameters:
       instances: 0 # overridden in build-extension-file.sh
-      memory: 1G
+      memory: 1500M
       disk-quota: 1G
       stack: cflinuxfs4
       routes:


### PR DESCRIPTION
## Problem

In Production deployments Go modules might approach memory limits (out of memory) under typical load during CF staging process

```
[PollStageAppStatusExecution] 3330a4ef-cfbd-4f7b-b959-09904192aa0c [2026-08-05T09:04:42.239884] -----> Running: go install -tags cloudfoundry -buildmode pie code.cloudfoundry.org/app-autoscaler/src/autoscaler/api/cmd/api (STDOUT, STG)
[PollStageAppStatusExecution] 3330a4ef-cfbd-4f7b-b959-09904192aa0c [2026-08-05T09:08:26.295677] encoding/gob: /tmp/contents1682767536/deps/0/go1.26.2/pkg/tool/linux_amd64/compile: signal: killed (STDERR, STG)
[PollStageAppStatusExecution] 3330a4ef-cfbd-4f7b-b959-09904192aa0c [2026-08-05T09:08:33.596469] **ERROR** Unable to compile application: exit status 1 (STDOUT, STG)
[PollStageAppStatusExecution] 3330a4ef-cfbd-4f7b-b959-09904192aa0c [2026-08-05T09:08:34.651936] Failed to compile droplet: Failed to run finalize script: exit status 12 (STDERR, STG)
[PollStageAppStatusExecution] 3330a4ef-cfbd-4f7b-b959-09904192aa0c [2026-08-05T09:08:34.659432] Exit status 223 (out of memory) (STDOUT, STG)
[PollStageAppStatusExecution] 3330a4ef-cfbd-4f7b-b959-09904192aa0c [2026-08-05T09:08:35.294296] Cell e79576ff-643b-4e8a-bcc8-72c25f327fca stopping instance e35bd44f-5fcc-43ed-970c-b4ad4527e10f (STDOUT, STG)
```

## Solution

Increased memory allocation from 1G to 1.5G for all Go-based modules. Additional headroom provides stability margin.