### PR TITLE
chore(mta): migrate app stack to cflinuxfs5

### DIFF
--- a/acceptance/assets/app/go_app/app_manifest.yml
+++ b/acceptance/assets/app/go_app/app_manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ((app_name))
-    stack: cflinuxfs4
+    stack: cflinuxfs5
     command: ./app
     routes:
       - route: ((app_name)).((app_domain))

--- a/cf/testdata/app.json
+++ b/cf/testdata/app.json
@@ -10,7 +10,7 @@
       "buildpacks": [
         "nodejs_buildpack"
       ],
-      "stack": "cflinuxfs3"
+      "stack": "cflinuxfs5"
     }
   },
   "relationships": {

--- a/ci/operations/add-trusted-certs.yaml
+++ b/ci/operations/add-trusted-certs.yaml
@@ -1,5 +1,10 @@
 # Add the router CA as a trusted certificate to all containers. This ensures that the containers within the
 # multiapps-controller can validate the cloud controller API's self-signed certificate.
+# Applied to both the cflinuxfs4 and cflinuxfs5 rootfs so apps on either stack trust the router CA
+# during the fs4 -> fs5 migration.
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs/trusted_certs/-
+  value: ((router_ca.ca))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs5-rootfs-setup/properties/cflinuxfs5-rootfs/trusted_certs/-
   value: ((router_ca.ca))

--- a/mta.tpl.yaml
+++ b/mta.tpl.yaml
@@ -108,7 +108,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1500M
       disk-quota: 1G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       routes:
   - name: eventgenerator
     type: go
@@ -134,7 +134,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1500M
       disk-quota: 1G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       routes:
   - name: metricsforwarder
     type: go
@@ -161,7 +161,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1500M
       disk-quota: 1G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       routes:
   - name: metricsgateway
     type: go
@@ -187,7 +187,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1500M
       disk-quota: 512M
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       routes:
   - name: operator
     type: go
@@ -213,7 +213,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1500M
       disk-quota: 1G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       routes:
   - name: scalingengine
     type: go
@@ -239,7 +239,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1500M
       disk-quota: 1G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       routes:
   - name: scheduler
     type: java
@@ -269,7 +269,7 @@ modules:
       instances: 0 # overridden in build-extension-file.sh
       memory: 1G
       disk-quota: 1G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       buildpack: ${java-buildpack}
       routes:
   - name: acceptance-tests
@@ -299,7 +299,7 @@ modules:
       no-start: true
       memory: 2G
       disk-quota: 2G
-      stack: cflinuxfs4
+      stack: cflinuxfs5
       buildpack: binary_buildpack
       tasks:
         - name: run-acceptance-tests


### PR DESCRIPTION
# Issue

Apps and the CI diego-cell were pinned to `cflinuxfs4`.

`cflinuxfs4` is based on Ubuntu Jammy, which reaches end of standard support in May 2027.

# Fix

Set every MTA module `stack:` to `cflinuxfs5`, plus the acceptance test
app manifest and the `cf/testdata/app.json` fixture.

Add a second `add-trusted-certs` op targeting `cflinuxfs5-rootfs-setup`
so the router CA is trusted on both rootfs during the fs4 -> fs5
migration (the current cf-deployment diego-cell ships both jobs). The
fs4 op is kept.
