### PR TITLE
chore(renovate): increase priority for Spring (Boot) updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -89,6 +89,12 @@
       ]
     },
     {
+      "description": "Prioritize Spring updates over others",
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["/springframework/"],
+      "prPriority": 10
+    },
+    {
       "description": "Disable Liquibase updates due to Functional Source License (FSL)",
       "groupName": "Liquibase",
       "matchManagers": [


### PR DESCRIPTION
Spring updates often resolve many CVEs in the transitive dependency tree. 

This `packageRule` currently would match `org.springframework.boot` as the parent POM for the scheduler and increase the PR prio, see also https://docs.renovatebot.com/configuration-options/#packagerulesprpriority