### PR TITLE
Use UTC as the explicit timezone

### DIFF
--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -3,7 +3,7 @@ name: Resume CI VMs
 on:
   schedule:
     - cron: '30 4 * * 1-5'  # 04:30 UTC / 05:30 CET / 06:30 CEST, Monday to Friday
-      timezone: "UTC"
+      timezone: "Etc/UTC"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -3,6 +3,7 @@ name: Resume CI VMs
 on:
   schedule:
     - cron: '30 4 * * 1-5'  # 04:30 UTC / 05:30 CET / 06:30 CEST, Monday to Friday
+      timezone: "UTC"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We currently ran into issues with the cron job not running at the expected time. To fix this we set the timezone explicitly to UTC