### PR TITLE
refactor(api): replace go-chi with stdlib http.ServeMux

### DIFF
--- a/api/brokerserver/broker_server.go
+++ b/api/brokerserver/broker_server.go
@@ -18,7 +18,6 @@ import (
 	"code.cloudfoundry.org/brokerapi/v13"
 	"code.cloudfoundry.org/brokerapi/v13/domain"
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/go-chi/chi/v5"
 	"github.com/tedsuo/ifrit"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -64,7 +63,7 @@ func (am *AuthMiddleware) authenticate(r *http.Request) bool {
 
 type BrokerServer interface {
 	CreateServer() (ifrit.Runner, error)
-	GetRouter() (*chi.Mux, error)
+	GetRouter() (*http.ServeMux, error)
 }
 
 type brokerServer struct {
@@ -140,7 +139,7 @@ func loadCatalog(path string, logger lager.Logger) ([]domain.Service, error) {
 	return catalog.Services, nil
 }
 
-func (s *brokerServer) GetRouter() (*chi.Mux, error) {
+func (s *brokerServer) GetRouter() (*http.ServeMux, error) {
 	credentialsList, err := prepareCredentials(s.logger, s.conf)
 	if err != nil {
 		return nil, err
@@ -158,10 +157,10 @@ func (s *brokerServer) GetRouter() (*chi.Mux, error) {
 		s.cfClient, s.bindingDB, s.policyDB,
 		catalog, s.credentials)
 
-	router := chi.NewRouter()
+	router := http.NewServeMux()
 
 	brokerAPI := brokerapi.NewWithOptions(autoscalerBroker, slog.New(lager.NewHandler(s.logger.Session("broker_handler"))), brokerapi.WithCustomAuth(authMiddleware.Middleware), brokerapi.WithAdditionalMiddleware(httpStatusMiddleware.Collect))
-	router.Handle(("/*"), brokerAPI)
+	router.Handle("/", brokerAPI)
 
 	router.HandleFunc(routes.HealthPath, GetHealth)
 

--- a/api/publicapiserver/public_api_server_test.go
+++ b/api/publicapiserver/public_api_server_test.go
@@ -12,7 +12,6 @@ import (
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
-	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit/ginkgomon_v2"
@@ -509,8 +508,8 @@ var _ = Describe("PublicApiServer", func() {
 
 		When("calling broker endpoint", func() {
 			BeforeEach(func() {
-				router := chi.NewRouter()
-				router.Get("/v2/catalog", func(w http.ResponseWriter, r *http.Request) {
+				router := http.NewServeMux()
+				router.HandleFunc("GET /v2/catalog", func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 					_, err := w.Write([]byte(`Service Broker`))
 					Expect(err).NotTo(HaveOccurred())

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cloud-gov/go-cfenv v1.19.1
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-beta.1
-	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,6 @@ github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZ
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
 github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01KS3zGE=
 github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
-github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
-github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
 github.com/go-faster/errors v0.7.1/go.mod h1:5ySTjWFiphBs07IKuiL69nxdfd5+fzh1u7FPGZP2quo=
 github.com/go-faster/jx v1.2.0 h1:T2YHJPrFaYu21fJtUxC9GzmluKu8rVIFDwwGBKTDseI=


### PR DESCRIPTION
# Issue

go-chi was used, even though stdlib `ServeMux` is a drop-in replacement. The broker router is only ever consumed as a plain `http.Handler` and uses no chi-specific features (URL params, middleware chains, sub-routers).

# Fix

Replaced go-chi with stdlib.