### PR TITLE
🚀 Speedup by grouping dependency-updates into fewer PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -106,7 +106,7 @@
       "enabled": false
     },
     {
-      "description": "Group together clis that are likely to have no impact on the result of the acceptance-tests. This is for speed-increase and to reduce the traffic-jam in the renovate-dependecy-dashboard <https://github.com/cloudfoundry/app-autoscaler/issues/832>.",
+      "description": "Group together dependencies that are likely to have no impact on the result of the acceptance-tests. This is for speed-increase and to reduce the traffic-jam in the renovate-dependecy-dashboard <https://github.com/cloudfoundry/app-autoscaler/issues/832>.",
       "groupName": "Low risk cli-updates",
       "matchManagers": ["devbox"],
       "prPriority": -1,
@@ -122,9 +122,11 @@
         "gnused",
         "gnutar",
         "gopls",
+        "gum",
         "jdt-language-server",
         "jq",
         "maven",
+        "oha",
         "openssl",
         "python",
         "ripgrep",

--- a/renovate.json
+++ b/renovate.json
@@ -104,6 +104,35 @@
         "/^org\\.liquibase:.*/"
       ],
       "enabled": false
+    },
+    {
+      "description": "Group together clis that are likely to have no impact on the result of the acceptance-tests. This is for speed-increase and to reduce the traffic-jam in the renovate-dependecy-dashboard <https://github.com/cloudfoundry/app-autoscaler/issues/832>.",
+      "groupName": "Low risk cli-updates",
+      "matchManagers": ["devbox"],
+      "prPriority": -1,
+      "matchDepNames": [
+        "bash-language-server",
+        "cloudfoundry-cli",
+        "coreutils",
+        "credhub-cli",
+        "curl",
+        "delve",
+        "gh",
+        "gnumake",
+        "gnused",
+        "gnutar",
+        "gopls",
+        "jdt-language-server",
+        "jq",
+        "maven",
+        "openssl",
+        "python",
+        "ripgrep",
+        "shellcheck",
+        "which",
+        "xq-xml",
+        "yq-go"
+      ]
     }
   ],
   "nix": {


### PR DESCRIPTION
This change groups all dependencies together that are unlikely to have an impact on the outcome of the acceptance-tests. So stable clis, ide-tools and the relatively stable linter shellcheck.